### PR TITLE
Defer JSON decoding of message arguments until handler invocation

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package wrapper
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 )
@@ -141,9 +142,19 @@ func (c *Client) sendEvent(ctx context.Context, channel string, arguments ...any
 	if conn == nil {
 		return fmt.Errorf("connection is closed")
 	}
+	// Encode arguments as JSON
+	jsonArgs := make([]json.RawMessage, len(arguments))
+	for i, arg := range arguments {
+		buf, err := json.Marshal(arg)
+		if err != nil {
+			return err
+		}
+		jsonArgs[i] = buf
+	}
+	// Send event to client
 	return conn.WriteMessage(ctx, &Message{
 		Channel:   channel,
-		Arguments: arguments,
+		Arguments: jsonArgs,
 	})
 }
 
@@ -175,10 +186,19 @@ func (c *Client) sendRequest(
 		c.server.requestMu.Unlock()
 	}
 
+	// Encode arguments as JSON
+	jsonArgs := make([]json.RawMessage, len(arguments))
+	for i, arg := range arguments {
+		buf, err := json.Marshal(arg)
+		if err != nil {
+			return nil, err
+		}
+		jsonArgs[i] = buf
+	}
 	// Send request to client
 	err := conn.WriteMessage(ctx, &Message{
 		Channel:   channel,
-		Arguments: arguments,
+		Arguments: jsonArgs,
 		RequestID: &requestID,
 	})
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -170,6 +170,16 @@ func (c *Client) sendRequest(
 		return nil, fmt.Errorf("connection is closed")
 	}
 
+	// Encode arguments as JSON
+	jsonArgs := make([]json.RawMessage, len(arguments))
+	for i, arg := range arguments {
+		buf, err := json.Marshal(arg)
+		if err != nil {
+			return nil, err
+		}
+		jsonArgs[i] = buf
+	}
+
 	// Create channel for message response
 	respCh := make(chan messageResponse, 1)
 
@@ -186,15 +196,6 @@ func (c *Client) sendRequest(
 		c.server.requestMu.Unlock()
 	}
 
-	// Encode arguments as JSON
-	jsonArgs := make([]json.RawMessage, len(arguments))
-	for i, arg := range arguments {
-		buf, err := json.Marshal(arg)
-		if err != nil {
-			return nil, err
-		}
-		jsonArgs[i] = buf
-	}
 	// Send request to client
 	err := conn.WriteMessage(ctx, &Message{
 		Channel:   channel,

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -2,6 +2,7 @@ package wrapper
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -84,7 +85,7 @@ func TestCallHandler(t *testing.T) {
 					FloatSlice:  slice,
 				}, nil
 			},
-			Arguments: []any{[]float64{1.2, 2.7, 3, 4}},
+			Arguments: []any{[]float64{1, 2, 3, 4}},
 			Response: TestStruct{
 				StringSlice: []string{"hmm", "ok"},
 				FloatSlice:  []float64{1, 2, 3, 4},
@@ -93,7 +94,17 @@ func TestCallHandler(t *testing.T) {
 	}
 	for _, ht := range tests {
 		name := ht.Name
-		res, err := callHandler(ctx, ht.Handler, ht.Arguments)
+		jsonArgs := make([]json.RawMessage, len(ht.Arguments))
+		for i, arg := range ht.Arguments {
+			buf, err := json.Marshal(arg)
+			if err != nil {
+				t.Errorf(name+": JSON encoding error: %v", err)
+				continue
+			}
+			jsonArgs[i] = buf
+		}
+
+		res, err := callHandler(ctx, ht.Handler, jsonArgs)
 		if ht.Error != nil {
 			if err == nil {
 				t.Errorf(name+": expected error %v", ht.Error)

--- a/server_test.go
+++ b/server_test.go
@@ -39,7 +39,7 @@ func ExampleServer_echo() {
 }
 
 // Demonstrates how to add various event handlers.
-func ExampleServerChannelOn() {
+func ExampleServerChannel_On() {
 	wsServer := NewServer()
 
 	// Simple event handler that does not return a response
@@ -65,7 +65,7 @@ func ExampleServerChannelOn() {
 }
 
 // Demonstrates adding event handlers to a particular channel.
-func ExampleServerChannelOn_channel() {
+func ExampleServerChannel_On_channel() {
 	wsServer := NewServer()
 
 	// Adds a "readFile" event handler to the "io" channel.


### PR DESCRIPTION
Previously `Message.Arguments` was of type `[]any`, and inbound JSON messages were directly decoded into `Arguments`, probably as `map[string]any` values. Now, `Message.Arguments` is of type `[]json.RawMessage`, which defers JSON decoding for each argument until the handler is invoked. Not only is performance improved in some cases, but now the JSON is decoded directly into the handler parameter types.

Closes #2