### PR TITLE
WIP: Add anonymous channel support

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -10,8 +10,9 @@ import (
 // remote end. See ClientChannel.On for more information about how received
 // events are handled.
 type ClientChannel struct {
-	name   string
-	client *Client
+	name      string
+	client    *Client
+	anonymous bool // true for anonymous channels
 }
 
 // On adds an event handler for the specified event to the channel. When an
@@ -86,7 +87,7 @@ func (c ClientChannel) On(eventName string, handler any) ClientChannel {
 	if err := checkHandler(c.name, eventName, handler); err != nil {
 		panic(err)
 	}
-	key := handlerName{Channel: c.name, Event: eventName}
+	key := handlerName{Channel: c.name, Event: eventName, Anonymous: c.anonymous}
 	c.client.handlersMu.Lock()
 	if handler == nil {
 		delete(c.client.handlers, key)
@@ -104,7 +105,7 @@ func (c ClientChannel) Once(eventName string, handler any) ClientChannel {
 	if err := checkHandler(c.name, eventName, handler); err != nil {
 		panic(err)
 	}
-	key := handlerName{Channel: c.name, Event: eventName}
+	key := handlerName{Channel: c.name, Event: eventName, Anonymous: c.anonymous}
 	c.client.handlersMu.Lock()
 	if handler == nil {
 		delete(c.client.handlersOnce, key)
@@ -137,10 +138,19 @@ func (c ClientChannel) Emit(ctx context.Context, arguments ...any) error {
 	if err != nil {
 		return err
 	}
-	if c.name == "" && IsReservedEvent(eventName) {
+	if !c.anonymous && c.name == "" && IsReservedEvent(eventName) {
 		return fmt.Errorf(
 			"cannot emit reserved event '%s' on main channel", eventName,
 		)
+	}
+	if c.anonymous {
+		if c.client.isAnonChannelClosed(c.name) {
+			return fmt.Errorf("anonymous channel '%s' is closed", c.name)
+		}
+		return c.client.sendAnonEvent(ctx, c.name, arguments...)
+	}
+	if c.client.isChannelClosed(c.name) {
+		return fmt.Errorf("channel '%s' is closed", c.name)
 	}
 	return c.client.sendEvent(ctx, c.name, arguments...)
 }
@@ -155,12 +165,52 @@ func (c ClientChannel) Request(
 	if err != nil {
 		return nil, err
 	}
+	if !c.anonymous && c.name == "" && IsReservedEvent(eventName) {
+		return nil, fmt.Errorf(
+			"cannot emit reserved event '%s' on main channel", eventName,
+		)
+	}
+	if c.anonymous {
+		if c.client.isAnonChannelClosed(c.name) {
+			return nil, fmt.Errorf("anonymous channel '%s' is closed", c.name)
+		}
+		return c.client.sendAnonRequest(ctx, c.name, arguments...)
+	}
+	if c.client.isChannelClosed(c.name) {
+		return nil, fmt.Errorf("channel '%s' is closed", c.name)
+	}
+	return c.client.sendRequest(ctx, c.name, arguments...)
+}
+
+// RequestChannel sends a request to the client and expects the remote handler
+// to return an anonymous channel. If the remote handler returns a normal value
+// instead, an error is returned.
+func (c ClientChannel) RequestChannel(
+	ctx context.Context, arguments ...any,
+) (*ClientChannel, error) {
+	eventName, err := checkEventName(arguments)
+	if err != nil {
+		return nil, err
+	}
 	if c.name == "" && IsReservedEvent(eventName) {
 		return nil, fmt.Errorf(
 			"cannot emit reserved event '%s' on main channel", eventName,
 		)
 	}
-	return c.client.sendRequest(ctx, c.name, arguments...)
+	return c.client.sendRequestChannel(ctx, c.name, arguments...)
+}
+
+// Close closes the channel. For anonymous channels, this sends {h, x} to the
+// remote end to signal that the channel is closed, cancels the channel context,
+// and removes all handlers. For named channels, this removes all handlers and
+// marks the channel as closed so that subsequent Emit and Request calls return
+// an error. Close is idempotent.
+func (c ClientChannel) Close() {
+	if c.anonymous {
+		c.client.closeAnonChannel(c.name)
+	} else {
+		c.client.closeNamedChannel(c.name)
+	}
 }
 
 // Name returns the name of the channel

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 )
 
@@ -12,6 +13,22 @@ import (
 // new connection. readMessages detects it to exit silently instead of treating
 // the context cancellation as a real connection error.
 var errRebound = errors.New("client bound to new connection")
+
+// requestIDKeyType is the context key type for injecting request IDs into
+// handler contexts.
+type requestIDKeyType struct{}
+
+// requestIDKey is the context key used to inject the request ID into the
+// handler context. Used by Client.Channel to retrieve the request ID.
+var requestIDKey = requestIDKeyType{}
+
+// anonChannelState holds the state of an anonymous channel.
+type anonChannelState struct {
+	channel *ClientChannel
+	ctx     context.Context
+	cancel  context.CancelCauseFunc
+	closed  bool // true after Close() or closeFromRemote() is called
+}
 
 // Client represents a WebSocket client
 type Client struct {
@@ -30,6 +47,10 @@ type Client struct {
 	dataMu            sync.Mutex
 	data              map[string]any
 	server            *Server // server associated with the Client
+	anonChannelsMu    sync.Mutex
+	anonChannels      map[string]*anonChannelState // keyed by channel ID (request ID as string)
+	closedChannelsMu  sync.Mutex
+	closedChannels    map[string]bool // tracks closed named channels
 }
 
 // NewClient creates a new Client not associated with any Server. Register
@@ -60,6 +81,8 @@ func NewClient(conn Conn) *Client {
 		handlers:          make(map[handlerName]any),
 		handlersOnce:      make(map[handlerName]any),
 		data:              make(map[string]any),
+		anonChannels:      make(map[string]*anonChannelState),
+		closedChannels:    make(map[string]bool),
 		// server is set only by Server.Accept
 	}
 	// Set channel reference back to client, so channel methods work properly
@@ -338,6 +361,324 @@ func (c *Client) sendRequest(
 	}
 }
 
+// Channel creates or retrieves an anonymous channel tied to the current request
+// context. Returns nil if called outside of a request handler context. Calling
+// Channel with the same context returns the same *ClientChannel (idempotent).
+func (c *Client) Channel(ctx context.Context) *ClientChannel {
+	reqID, ok := ctx.Value(requestIDKey).(int)
+	if !ok {
+		return nil
+	}
+	id := strconv.Itoa(reqID)
+
+	c.anonChannelsMu.Lock()
+	if state, exists := c.anonChannels[id]; exists {
+		c.anonChannelsMu.Unlock()
+		return state.channel
+	}
+
+	// Derive channel context from the client's connection context (not the
+	// handler context) so the anonymous channel outlives the handler call.
+	c.connReqMu.Lock()
+	clientCtx := c.ctx
+	c.connReqMu.Unlock()
+
+	chCtx, chCancel := context.WithCancelCause(clientCtx)
+	ch := &ClientChannel{name: id, client: c, anonymous: true}
+	c.anonChannels[id] = &anonChannelState{
+		channel: ch,
+		ctx:     chCtx,
+		cancel:  chCancel,
+	}
+	c.anonChannelsMu.Unlock()
+
+	// Watch for context cancellation to auto-close the channel
+	go c.watchAnonChannelContext(id, chCtx)
+
+	return ch
+}
+
+// sendAnonEvent sends an event on an anonymous channel
+func (c *Client) sendAnonEvent(ctx context.Context, anonID string, arguments ...any) error {
+	c.connReqMu.Lock()
+	conn := c.conn
+	c.connReqMu.Unlock()
+	if conn == nil {
+		return fmt.Errorf("connection is closed")
+	}
+	jsonArgs := make([]json.RawMessage, len(arguments))
+	for i, arg := range arguments {
+		buf, err := json.Marshal(arg)
+		if err != nil {
+			return err
+		}
+		jsonArgs[i] = buf
+	}
+	return conn.WriteMessage(ctx, &Message{
+		AnonChannel: anonID,
+		Arguments:   jsonArgs,
+	})
+}
+
+// sendAnonRequest sends a request on an anonymous channel and returns the response
+func (c *Client) sendAnonRequest(
+	ctx context.Context, anonID string, arguments ...any,
+) (any, error) {
+	c.connReqMu.Lock()
+	conn := c.conn
+	ctxClient := c.ctx
+	if conn == nil {
+		c.connReqMu.Unlock()
+		return nil, fmt.Errorf("connection is closed")
+	}
+	respCh := make(chan messageResponse, 1)
+	c.requestID++
+	requestID := c.requestID
+	if c.requestResponseCh[requestID] != nil {
+		c.connReqMu.Unlock()
+		return nil, fmt.Errorf("request ID %d already in use", requestID)
+	}
+	c.requestResponseCh[requestID] = respCh
+	c.connReqMu.Unlock()
+
+	jsonArgs := make([]json.RawMessage, len(arguments))
+	for i, arg := range arguments {
+		buf, err := json.Marshal(arg)
+		if err != nil {
+			return nil, err
+		}
+		jsonArgs[i] = buf
+	}
+	err := conn.WriteMessage(ctx, &Message{
+		AnonChannel: anonID,
+		Arguments:   jsonArgs,
+		RequestID:   &requestID,
+	})
+	if err != nil {
+		c.connReqMu.Lock()
+		delete(c.requestResponseCh, requestID)
+		c.connReqMu.Unlock()
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+
+	select {
+	case resp, ok := <-respCh:
+		if !ok {
+			return nil, fmt.Errorf("response channel closed unexpectedly")
+		}
+		return resp.Data, resp.Error
+	case <-ctxClient.Done():
+		return nil, fmt.Errorf("awaiting response: %w", context.Cause(ctxClient))
+	case <-ctx.Done():
+		return nil, fmt.Errorf("awaiting response: %w", context.Cause(ctx))
+	}
+}
+
+// sendRequestChannel sends a request expecting an anonymous channel response.
+// The response must contain an AnonChannel field; otherwise an error is returned.
+func (c *Client) sendRequestChannel(
+	ctx context.Context, channel string, arguments ...any,
+) (*ClientChannel, error) {
+	c.connReqMu.Lock()
+	conn := c.conn
+	ctxClient := c.ctx
+	if conn == nil {
+		c.connReqMu.Unlock()
+		return nil, fmt.Errorf("connection is closed")
+	}
+	respCh := make(chan messageResponse, 1)
+	c.requestID++
+	requestID := c.requestID
+	if c.requestResponseCh[requestID] != nil {
+		c.connReqMu.Unlock()
+		return nil, fmt.Errorf("request ID %d already in use", requestID)
+	}
+	c.requestResponseCh[requestID] = respCh
+	c.connReqMu.Unlock()
+
+	jsonArgs := make([]json.RawMessage, len(arguments))
+	for i, arg := range arguments {
+		buf, err := json.Marshal(arg)
+		if err != nil {
+			return nil, err
+		}
+		jsonArgs[i] = buf
+	}
+	err := conn.WriteMessage(ctx, &Message{
+		Channel:   channel,
+		Arguments: jsonArgs,
+		RequestID: &requestID,
+	})
+	if err != nil {
+		c.connReqMu.Lock()
+		delete(c.requestResponseCh, requestID)
+		c.connReqMu.Unlock()
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+
+	select {
+	case resp, ok := <-respCh:
+		if !ok {
+			return nil, fmt.Errorf("response channel closed unexpectedly")
+		}
+		if resp.Error != nil {
+			return nil, resp.Error
+		}
+		// resp.Data should be the anonymous channel signal
+		anonCh, ok := resp.Data.(*ClientChannel)
+		if !ok || anonCh == nil {
+			return nil, fmt.Errorf(
+				"expected anonymous channel response, got normal value",
+			)
+		}
+		return anonCh, nil
+	case <-ctxClient.Done():
+		return nil, fmt.Errorf("awaiting response: %w", context.Cause(ctxClient))
+	case <-ctx.Done():
+		return nil, fmt.Errorf("awaiting response: %w", context.Cause(ctx))
+	}
+}
+
+// sendResolveAnon sends an anonymous channel creation response {i, h: "1"}
+func (c *Client) sendResolveAnon(ctx context.Context, requestID *int) error {
+	if requestID == nil {
+		return fmt.Errorf("requestID is required")
+	}
+	c.connReqMu.Lock()
+	conn := c.conn
+	c.connReqMu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	id := strconv.Itoa(*requestID)
+	return conn.WriteMessage(ctx, &Message{
+		RequestID:   requestID,
+		AnonChannel: id,
+	})
+}
+
+// sendAnonCancel sends {h, x} cancellation message for an anonymous channel
+func (c *Client) sendAnonCancel(anonID string) {
+	c.connReqMu.Lock()
+	conn := c.conn
+	ctx := c.ctx
+	c.connReqMu.Unlock()
+	if conn == nil {
+		return
+	}
+	// Best-effort send; ignore errors (connection may already be dead)
+	_ = conn.WriteMessage(ctx, &Message{
+		AnonChannel: anonID,
+		CancelReason: map[string]any{
+			"message": "channel closed",
+		},
+		ResponseJSError: true,
+	})
+}
+
+// closeAnonChannel closes an anonymous channel locally and sends {h, x} to
+// remote. Idempotent — second call is a no-op.
+func (c *Client) closeAnonChannel(anonID string) {
+	c.anonChannelsMu.Lock()
+	state, exists := c.anonChannels[anonID]
+	if !exists || state.closed {
+		c.anonChannelsMu.Unlock()
+		return
+	}
+	state.closed = true
+	c.anonChannelsMu.Unlock()
+
+	// Cancel the channel context
+	state.cancel(fmt.Errorf("anonymous channel closed"))
+
+	// Send {h, x} to remote
+	c.sendAnonCancel(anonID)
+
+	// Remove handlers
+	c.removeAnonChannelHandlers(anonID)
+}
+
+// closeAnonChannelFromRemote closes an anonymous channel due to receiving
+// {h, x} from the remote end. Does NOT send {h, x} back.
+func (c *Client) closeAnonChannelFromRemote(anonID string, cause error) {
+	c.anonChannelsMu.Lock()
+	state, exists := c.anonChannels[anonID]
+	if !exists || state.closed {
+		c.anonChannelsMu.Unlock()
+		return
+	}
+	state.closed = true
+	c.anonChannelsMu.Unlock()
+
+	// Cancel the channel context with the remote's cause
+	state.cancel(cause)
+
+	// Remove handlers
+	c.removeAnonChannelHandlers(anonID)
+}
+
+// removeAnonChannelHandlers removes all handlers for the given anonymous channel
+func (c *Client) removeAnonChannelHandlers(anonID string) {
+	c.handlersMu.Lock()
+	for key := range c.handlers {
+		if key.Anonymous && key.Channel == anonID {
+			delete(c.handlers, key)
+		}
+	}
+	for key := range c.handlersOnce {
+		if key.Anonymous && key.Channel == anonID {
+			delete(c.handlersOnce, key)
+		}
+	}
+	c.handlersMu.Unlock()
+}
+
+// closeNamedChannel closes a named channel by removing its handlers and marking
+// it as closed.
+func (c *Client) closeNamedChannel(name string) {
+	c.closedChannelsMu.Lock()
+	c.closedChannels[name] = true
+	c.closedChannelsMu.Unlock()
+
+	c.handlersMu.Lock()
+	for key := range c.handlers {
+		if !key.Anonymous && key.Channel == name {
+			delete(c.handlers, key)
+		}
+	}
+	for key := range c.handlersOnce {
+		if !key.Anonymous && key.Channel == name {
+			delete(c.handlersOnce, key)
+		}
+	}
+	c.handlersMu.Unlock()
+}
+
+// isAnonChannelClosed returns whether the anonymous channel is closed
+func (c *Client) isAnonChannelClosed(anonID string) bool {
+	c.anonChannelsMu.Lock()
+	defer c.anonChannelsMu.Unlock()
+	state, exists := c.anonChannels[anonID]
+	if !exists {
+		return true // channel doesn't exist, treat as closed
+	}
+	return state.closed
+}
+
+// isChannelClosed returns whether a named channel is closed
+func (c *Client) isChannelClosed(name string) bool {
+	c.closedChannelsMu.Lock()
+	defer c.closedChannelsMu.Unlock()
+	return c.closedChannels[name]
+}
+
+// watchAnonChannelContext watches the anonymous channel context and calls
+// closeAnonChannel when it is cancelled (idempotent).
+func (c *Client) watchAnonChannelContext(anonID string, ctx context.Context) {
+	<-ctx.Done()
+	c.closeAnonChannel(anonID)
+}
+
 // readMessages reads messages from the client connection and handles them.
 // Cancel the context to stop reading messages
 func (c *Client) readMessages() {
@@ -464,6 +805,13 @@ func (c *Client) emitClose(s StatusCode, reason string, userClosed bool) bool {
 // handleMessage processes an inbound message for this client. Returns an error
 // if there was an error sending the response to the client.
 func (c *Client) handleMessage(ctx context.Context, msg Message) error {
+	// Handle anonymous channel event/request messages.
+	// Note: creation responses ({i, h} with no event name) are handled below
+	// in the standard response section.
+	if msg.AnonChannel != "" && (msg.EventName() != "" || msg.CancelReason != nil) {
+		return c.handleAnonMessage(ctx, msg)
+	}
+
 	// We may create a request-specific cancellable context later
 	var cancel context.CancelCauseFunc
 	// Get message event name if any
@@ -526,6 +874,8 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 		// to allow a protocol-level cancellation message to cancel the handler.
 		if msg.RequestID != nil {
 			handlerCtx, cancel = context.WithCancelCause(handlerCtx)
+			// Inject request ID into handler context for Client.Channel(ctx)
+			handlerCtx = context.WithValue(handlerCtx, requestIDKey, *msg.RequestID)
 			// Save the CancelCauseFunc for the request
 			c.inboundCancelsMu.Lock()
 			c.inboundCancels[*msg.RequestID] = cancel
@@ -556,6 +906,9 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 			if err != nil {
 				// Send error response
 				err = c.sendReject(ctx, msg.RequestID, err)
+			} else if ch, ok := result.(*ClientChannel); ok && ch != nil && ch.anonymous {
+				// Handler returned an anonymous channel — send {i, h}
+				err = c.sendResolveAnon(ctx, msg.RequestID)
 			} else {
 				// Send data response
 				err = c.sendResolve(ctx, msg.RequestID, result)
@@ -581,6 +934,15 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 
 	// Handle request cancellation message (ws-wrapper v4)
 	if msg.CancelReason != nil {
+		// Ignore {i, x} for request IDs that have an open anonymous channel
+		c.anonChannelsMu.Lock()
+		anonID := strconv.Itoa(*msg.RequestID)
+		_, hasAnon := c.anonChannels[anonID]
+		c.anonChannelsMu.Unlock()
+		if hasAnon {
+			return nil // anonymous channel has its own lifecycle via {h, x}
+		}
+
 		c.inboundCancelsMu.Lock()
 		cancel, ok := c.inboundCancels[*msg.RequestID]
 		if ok {
@@ -604,10 +966,127 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 		return nil // ignore message with invalid request ID
 	}
 
+	// Check if this is an anonymous channel creation response {i, h}
+	if msg.AnonChannel != "" {
+		// Create local anonymous channel for the requestor side
+		anonID := strconv.Itoa(*msg.RequestID)
+		chCtx, chCancel := context.WithCancelCause(ctx)
+		ch := &ClientChannel{name: anonID, client: c, anonymous: true}
+		c.anonChannelsMu.Lock()
+		c.anonChannels[anonID] = &anonChannelState{
+			channel: ch,
+			ctx:     chCtx,
+			cancel:  chCancel,
+		}
+		c.anonChannelsMu.Unlock()
+		go c.watchAnonChannelContext(anonID, chCtx)
+		respCh <- messageResponse{Data: ch}
+		close(respCh)
+		return nil
+	}
+
 	// Process response
 	res, err := msg.Response()
 	respCh <- messageResponse{res, err}
 	close(respCh)
 
+	return nil
+}
+
+// handleAnonMessage handles a message destined for an anonymous channel.
+// Only called for messages with AnonChannel set and either an event name or
+// a CancelReason.
+func (c *Client) handleAnonMessage(ctx context.Context, msg Message) error {
+	anonID := msg.AnonChannel
+
+	// Handle {h, x} cancellation from remote
+	if msg.CancelReason != nil {
+		defer close(msg.processed)
+		c.closeAnonChannelFromRemote(anonID, msg.CancelCause())
+		return nil
+	}
+
+	eventName := msg.EventName()
+
+	// Look up handler for this anonymous channel
+	handlerID := handlerName{Channel: anonID, Event: eventName, Anonymous: true}
+
+	c.handlersMu.Lock()
+	handler, ok := c.handlersOnce[handlerID]
+	if ok {
+		delete(c.handlersOnce, handlerID)
+	} else {
+		handler = c.handlers[handlerID]
+	}
+	c.handlersMu.Unlock()
+
+	if handler == nil {
+		defer close(msg.processed)
+		err := fmt.Errorf(
+			"no event listener for '%s' on anonymous channel '%s'",
+			eventName, anonID,
+		)
+		if msg.RequestID != nil {
+			return c.sendReject(ctx, msg.RequestID, err)
+		}
+		return nil
+	}
+
+	// Get handler context from the anonymous channel state
+	c.anonChannelsMu.Lock()
+	state := c.anonChannels[anonID]
+	c.anonChannelsMu.Unlock()
+
+	handlerCtx := ctx
+	if state != nil {
+		handlerCtx = state.ctx
+	}
+
+	// Get server's handler Context function
+	if c.server != nil {
+		c.server.handlersMu.Lock()
+		if c.server.handlerCtxFunc != nil {
+			handlerCtx = c.server.handlerCtxFunc(handlerCtx, anonID, eventName)
+		}
+		c.server.handlersMu.Unlock()
+	}
+
+	var cancel context.CancelCauseFunc
+	if msg.RequestID != nil {
+		handlerCtx, cancel = context.WithCancelCause(handlerCtx)
+		c.inboundCancelsMu.Lock()
+		c.inboundCancels[*msg.RequestID] = cancel
+		c.inboundCancelsMu.Unlock()
+	}
+
+	go func() {
+		defer close(msg.processed)
+		result, err := callHandler(handlerCtx, handler, msg.HandlerArguments())
+		if cancel != nil {
+			cancel(context.Canceled)
+		}
+
+		if msg.RequestID == nil {
+			return
+		}
+
+		c.inboundCancelsMu.Lock()
+		delete(c.inboundCancels, *msg.RequestID)
+		c.inboundCancelsMu.Unlock()
+
+		if err != nil {
+			err = c.sendReject(ctx, msg.RequestID, err)
+		} else {
+			err = c.sendResolve(ctx, msg.RequestID, result)
+		}
+		if err != nil {
+			err = fmt.Errorf("responding to request: %w", err)
+			c.emitError(err)
+			if c.server != nil {
+				c.server.emitError(c, err)
+			}
+			c.close(StatusInternalError, err.Error(), false, false)
+		}
+	}()
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1000,3 +1000,468 @@ func TestBind_UserClosed(t *testing.T) {
 		}
 	})
 }
+
+// TestAnonymousChannelCreation verifies that a handler can create and return
+// an anonymous channel via Client.Channel(ctx), and the response includes {i, h}.
+func TestAnonymousChannelCreation(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	server.On("openCalc", func(ctx context.Context) (*ClientChannel, error) {
+		client := ClientFromContext(ctx)
+		ch := client.Channel(ctx)
+		if ch == nil {
+			return nil, fmt.Errorf("Channel() returned nil")
+		}
+		ch.On("add", func(a, b float64) (float64, error) {
+			return a + b, nil
+		})
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send request that should return an anonymous channel
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"openCalc"`)},
+	})
+
+	resp := conn.waitWritten(t, time.Second)
+	if resp.RequestID == nil || *resp.RequestID != reqID {
+		t.Fatalf("expected response for request %d, got %+v", reqID, resp)
+	}
+	if resp.AnonChannel == "" {
+		t.Fatal("expected AnonChannel field in response, got empty")
+	}
+	if resp.AnonChannel != "1" {
+		t.Fatalf("expected AnonChannel '1', got %q", resp.AnonChannel)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonymousChannelEventHandling verifies that events sent on an anonymous
+// channel are routed to the correct handler.
+func TestAnonymousChannelEventHandling(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	addCalled := make(chan float64, 1)
+	server.On("openCalc", func(ctx context.Context) (*ClientChannel, error) {
+		client := ClientFromContext(ctx)
+		ch := client.Channel(ctx)
+		ch.On("add", func(a, b float64) (float64, error) {
+			result := a + b
+			addCalled <- result
+			return result, nil
+		})
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create anonymous channel
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"openCalc"`)},
+	})
+	resp := conn.waitWritten(t, time.Second)
+	anonID := resp.AnonChannel
+
+	// Send request on anonymous channel
+	subReqID := 2
+	conn.send(Message{
+		AnonChannel: anonID,
+		RequestID:   &subReqID,
+		Arguments:   []json.RawMessage{[]byte(`"add"`), []byte(`3`), []byte(`4`)},
+	})
+
+	// Wait for handler to be called
+	select {
+	case result := <-addCalled:
+		if result != 7 {
+			t.Fatalf("expected 7, got %v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("add handler not called")
+	}
+
+	// Check response
+	subResp := conn.waitWritten(t, time.Second)
+	if subResp.RequestID == nil || *subResp.RequestID != subReqID {
+		t.Fatalf("expected response for request %d, got %+v", subReqID, subResp)
+	}
+	if subResp.ResponseData != 7.0 {
+		t.Fatalf("expected 7, got %v", subResp.ResponseData)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonymousChannelCloseLocal verifies that Close() on an anonymous channel
+// sends {h, x} to the remote and removes handlers.
+func TestAnonymousChannelCloseLocal(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var anonCh *ClientChannel
+	server.On("openCh", func(ctx context.Context) (*ClientChannel, error) {
+		client := ClientFromContext(ctx)
+		anonCh = client.Channel(ctx)
+		anonCh.On("ping", func() error { return nil })
+		return anonCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"openCh"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+
+	// Close the anonymous channel from server side
+	anonCh.Close()
+
+	// Should receive {h, x} cancellation message
+	cancelMsg := conn.waitWritten(t, time.Second)
+	if cancelMsg.AnonChannel == "" {
+		t.Fatal("expected AnonChannel in cancel message")
+	}
+	if cancelMsg.CancelReason == nil {
+		t.Fatal("expected CancelReason in cancel message")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonymousChannelCloseFromRemote verifies that receiving {h, x} closes
+// the channel locally without sending {h, x} back.
+func TestAnonymousChannelCloseFromRemote(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	closedCh := make(chan struct{}, 1)
+	server.On("openCh", func(ctx context.Context) (*ClientChannel, error) {
+		client := ClientFromContext(ctx)
+		ch := client.Channel(ctx)
+		ch.On("ping", func() error { return nil })
+		// Watch for channel context cancellation
+		go func() {
+			<-ch.client.anonChannels[ch.name].ctx.Done()
+			closedCh <- struct{}{}
+		}()
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"openCh"`)},
+	})
+	resp := conn.waitWritten(t, time.Second)
+	anonID := resp.AnonChannel
+
+	// Send {h, x} from remote
+	conn.send(Message{
+		AnonChannel: anonID,
+		CancelReason: map[string]any{
+			"message": "remote closed",
+		},
+		ResponseJSError: true,
+	})
+
+	// Channel context should be cancelled
+	select {
+	case <-closedCh:
+	case <-time.After(time.Second):
+		t.Fatal("channel context was not cancelled after remote close")
+	}
+
+	// Verify no {h, x} was sent back (only the creation response should be in writeCh)
+	select {
+	case msg := <-conn.writeCh:
+		t.Fatalf("unexpected message after remote close: %+v", msg)
+	case <-time.After(200 * time.Millisecond):
+		// Good — no extra message sent
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonymousChannelNamespacing verifies that anonymous channel "1" and
+// named channel "1" don't interfere with each other.
+func TestAnonymousChannelNamespacing(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	namedCalled := make(chan struct{}, 1)
+	anonCalled := make(chan struct{}, 1)
+
+	// Named channel "1" handler
+	server.Of("1").On("ping", func() error {
+		namedCalled <- struct{}{}
+		return nil
+	})
+
+	// Anonymous channel handler
+	server.On("openCh", func(ctx context.Context) (*ClientChannel, error) {
+		client := ClientFromContext(ctx)
+		ch := client.Channel(ctx)
+		ch.On("ping", func() error {
+			anonCalled <- struct{}{}
+			return nil
+		})
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create anonymous channel (will have ID "1")
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"openCh"`)},
+	})
+	resp := conn.waitWritten(t, time.Second)
+	anonID := resp.AnonChannel
+
+	// Send event on named channel "1"
+	conn.send(Message{
+		Channel:   "1",
+		Arguments: []json.RawMessage{[]byte(`"ping"`)},
+	})
+	select {
+	case <-namedCalled:
+	case <-time.After(time.Second):
+		t.Fatal("named channel handler not called")
+	}
+
+	// Send event on anonymous channel "1"
+	conn.send(Message{
+		AnonChannel: anonID,
+		Arguments:   []json.RawMessage{[]byte(`"ping"`)},
+	})
+	select {
+	case <-anonCalled:
+	case <-time.After(time.Second):
+		t.Fatal("anonymous channel handler not called")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestChannelIdempotent verifies that calling Channel(ctx) twice with the
+// same context returns the same *ClientChannel pointer.
+func TestChannelIdempotent(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var ch1, ch2 *ClientChannel
+	server.On("test", func(ctx context.Context) (*ClientChannel, error) {
+		client := ClientFromContext(ctx)
+		ch1 = client.Channel(ctx)
+		ch2 = client.Channel(ctx)
+		return ch1, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"test"`)},
+	})
+	conn.waitWritten(t, time.Second)
+
+	if ch1 != ch2 {
+		t.Fatal("Channel(ctx) should return the same pointer on second call")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestChannelOutsideHandler verifies that Channel(ctx) returns nil when
+// called outside of a request handler context.
+func TestChannelOutsideHandler(t *testing.T) {
+	client := NewClient(nil)
+	ch := client.Channel(context.Background())
+	if ch != nil {
+		t.Fatal("expected nil when Channel() called outside handler context")
+	}
+}
+
+// TestAnonymousChannelEmitAfterClose verifies that Emit returns an error
+// after the anonymous channel is closed.
+func TestAnonymousChannelEmitAfterClose(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var anonCh *ClientChannel
+	server.On("openCh", func(ctx context.Context) (*ClientChannel, error) {
+		client := ClientFromContext(ctx)
+		anonCh = client.Channel(ctx)
+		return anonCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"openCh"`)},
+	})
+	conn.waitWritten(t, time.Second)
+
+	anonCh.Close()
+	// Drain the cancel message
+	conn.waitWritten(t, time.Second)
+
+	err := anonCh.Emit(context.Background(), "ping")
+	if err == nil {
+		t.Fatal("expected error emitting on closed anonymous channel")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestNamedChannelClose verifies that Close() on a named channel removes
+// handlers and causes Emit/Request to return errors.
+func TestNamedChannelClose(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var capturedClient *Client
+	server.On("open", func(c *Client) {
+		capturedClient = c
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	ch := capturedClient.Of("test")
+	ch.On("ping", func() error { return nil })
+
+	ch.Close()
+
+	err := ch.Emit(context.Background(), "ping")
+	if err == nil {
+		t.Fatal("expected error emitting on closed named channel")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestRequestChannelMethod verifies the client-side RequestChannel method by
+// simulating a server that returns an anonymous channel.
+func TestRequestChannelMethod(t *testing.T) {
+	conn := newMockConn()
+	client := NewClient(conn)
+
+	// Simulate: client sends request, server responds with {i, h}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Wait for the outbound request
+		msg := conn.waitWritten(t, time.Second)
+		if msg.RequestID == nil {
+			t.Error("expected request ID")
+			return
+		}
+		reqID := *msg.RequestID
+
+		// Respond with anonymous channel signal
+		anonID := fmt.Sprintf("%d", reqID)
+		conn.send(Message{
+			RequestID:   &reqID,
+			AnonChannel: anonID,
+		})
+	}()
+
+	ch, err := client.RequestChannel(context.Background(), "openCalc")
+	if err != nil {
+		t.Fatalf("RequestChannel failed: %v", err)
+	}
+	if ch == nil {
+		t.Fatal("expected non-nil channel")
+	}
+	if !ch.anonymous {
+		t.Fatal("expected anonymous channel")
+	}
+
+	<-done
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestIgnoreIXForAnonChannel verifies that {i, x} cancellation messages are
+// ignored for request IDs that have an open anonymous channel.
+func TestIgnoreIXForAnonChannel(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var anonCh *ClientChannel
+	server.On("openCh", func(ctx context.Context) (*ClientChannel, error) {
+		client := ClientFromContext(ctx)
+		anonCh = client.Channel(ctx)
+		anonCh.On("ping", func() error { return nil })
+		return anonCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"openCh"`)},
+	})
+	conn.waitWritten(t, time.Second) // creation response
+
+	// Send {i, x} for the same request ID — should be ignored
+	conn.send(Message{
+		RequestID:    &reqID,
+		CancelReason: "cancel attempt",
+	})
+
+	// Channel should still be open
+	time.Sleep(100 * time.Millisecond)
+	if anonCh.client.isAnonChannelClosed(anonCh.name) {
+		t.Fatal("anonymous channel should not be closed by {i, x}")
+	}
+
+	// Verify the anonymous channel still works
+	subReqID := 2
+	conn.send(Message{
+		AnonChannel: anonCh.name,
+		RequestID:   &subReqID,
+		Arguments:   []json.RawMessage{[]byte(`"ping"`)},
+	})
+	resp := conn.waitWritten(t, time.Second)
+	if resp.RequestID == nil || *resp.RequestID != subReqID {
+		t.Fatalf("expected response for sub-request %d", subReqID)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}

--- a/handlers.go
+++ b/handlers.go
@@ -43,8 +43,9 @@ func IsReservedEvent(eventName string) bool {
 // handlerName is a unique name for a handler function having the specified
 // channel and event name.
 type handlerName struct {
-	Channel string
-	Event   string
+	Channel   string
+	Event     string
+	Anonymous bool // true for anonymous channel handlers
 }
 
 var errorType = reflect.TypeFor[error]()

--- a/message.go
+++ b/message.go
@@ -29,6 +29,7 @@ func (bit *weakBool) UnmarshalJSON(data []byte) error {
 // See https://github.com/bminer/ws-wrapper/blob/master/README.md#protocol
 type Message struct {
 	Channel         string            `json:"c,omitempty"`
+	AnonChannel     string            `json:"h,omitempty"` // Anonymous channel ID
 	Arguments       []json.RawMessage `json:"a,omitempty"` // Arguments[0] is the event name
 	RequestID       *int              `json:"i,omitempty"`
 	ResponseData    any               `json:"d,omitempty"`
@@ -99,7 +100,7 @@ func (m Message) Response() (any, error) {
 // CancelCause returns the reason for this cancellation message as an error.
 // Returns context.Canceled if no reason is provided.
 func (m Message) CancelCause() error {
-	if m.RequestID == nil || m.CancelReason == nil {
+	if m.CancelReason == nil {
 		return errors.New("message is not a cancellation")
 	}
 	// Handle JavaScript error
@@ -139,6 +140,9 @@ func (m Message) LogValue() slog.Value {
 		attrs = []slog.Attr{
 			slog.String("ch", m.Channel),
 			slog.String("event", eventName),
+		}
+		if m.AnonChannel != "" {
+			attrs = append(attrs, slog.String("anonCh", m.AnonChannel))
 		}
 		for i, arg := range m.HandlerArguments() {
 			if len(arg) > MaxArgLength {

--- a/message_test.go
+++ b/message_test.go
@@ -169,8 +169,8 @@ func TestMessageCancelCause(t *testing.T) {
 	t.Run("missing request ID", func(t *testing.T) {
 		msg := Message{CancelReason: "user cancelled"}
 		err := msg.CancelCause()
-		if err == nil || err.Error() != "message is not a cancellation" {
-			t.Errorf("expected 'message is not a cancellation', got %v", err)
+		if err == nil || err.Error() != "user cancelled" {
+			t.Errorf("expected 'user cancelled', got %v", err)
 		}
 	})
 


### PR DESCRIPTION
- Add AnonChannel (h) field to Message struct for wire protocol
- Add Anonymous bool to handlerName for namespace separation
- Extend ClientChannel with anonymous bool, Close(), and RequestChannel()
- Add anonChannelState and anonChannels map to Client
- Implement Client.Channel(ctx) - idempotent, returns nil outside handler
- Route inbound {h,...} messages to anonymous channel handlers
- Strategy B close: Close() sends {h,x}; closeFromRemote() does not
- Ignore {i,x} cancellations when an open anonymous channel exists
- Context watcher goroutine auto-closes channel when client disconnects
- Add 12 new tests covering creation, events, requests, close semantics, namespacing, idempotency, and cancellation edge cases