### PR TITLE
Add anonymous channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ Current ws-wrapper compatibility: **v4.1**.
 
 ## [Unreleased]
 
-- No unreleased library changes yet.
+### Added
+
+- Added `AnonymousChannel` type: a request handler can now return an `*AnonymousChannel` to open a bidirectional, request-scoped sub-channel over the same WebSocket connection.
+- Added `Channel(ctx)` helper to obtain the `*AnonymousChannel` for the current request handler context, creating it lazily on first call.
+- Added example demonstrating anonymous channel usage.
+
+### Changed
+
+- `ClientKey` context key has been removed. `ClientFromContext` still works as before; code that referenced `wrapper.ClientKey` directly should be updated to use `ClientFromContext` instead.
+- `Message` gained an `AnonymousChannel` field (`"h"` JSON key) for the anonymous channel protocol.
+- `Message.CancelCause` no longer requires a non-nil `RequestID`; it now also handles anonymous channel abort messages (`{h, x}`).
+- `Message.LogValue` updated to log anonymous-channel-specific fields (`anonCh`, `anonChCreated`) for the new message types.
 
 ## [1.6.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Current ws-wrapper compatibility: **v4.1**.
+Current ws-wrapper compatibility: **v4.3**.
 
 ## [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,45 @@ ioChannel := wsServer.Of("io")
 _ = ioChannel.Close()
 ```
 
+## Anonymous Channels
+
+Anonymous channels let a handler stream events or exchange multiple messages
+with the requesting client over a single WebSocket connection. Return a
+`*AnonymousChannel` from a handler to signal that data will follow
+asynchronously:
+
+```go
+wsServer.On("subscribe", func(ctx context.Context, topic string) (*wrapper.AnonymousChannel, error) {
+    ch := wrapper.Channel(ctx) // obtain the anonymous channel for this request
+    go func() {
+        defer ch.Close()
+        for _, update := range fetchUpdates(topic) {
+            if err := ch.Emit(ch.Context(), "data", update); err != nil {
+                return // client disconnected or aborted
+            }
+        }
+        ch.Emit(ch.Context(), "end")
+    }()
+    return ch, nil
+})
+```
+
+On the client side, the `Request` call resolves to a `*AnonymousChannel`:
+
+```go
+resp, err := client.Request(ctx, "subscribe", "news")
+if ch, ok := resp.(*wrapper.AnonymousChannel); ok {
+    ch.On("data", func(update string) error {
+        fmt.Println("update:", update)
+        return nil
+    })
+}
+```
+
+Either side can abort the channel early with `ch.Abort(err)`, which sends a
+cancel message to the remote end and closes the channel. `ch.Context()` returns
+a context that is cancelled when the channel closes or is aborted.
+
 ## Per-Client Handlers
 
 Register handlers on an individual `*Client`.

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -10,10 +10,10 @@ import (
 // *AnonymousChannel in response to a request. It allows streaming or
 // multi-message patterns over a single WebSocket connection.
 type AnonymousChannel struct {
-	id            int
-	ClientChannel // inherits name (string form of id) and Name()
-	ctx           context.Context
-	ctxCancel     context.CancelCauseFunc
+	id        int
+	client    *Client
+	ctx       context.Context
+	ctxCancel context.CancelCauseFunc
 }
 
 // newAnonymousChannel creates an AnonymousChannel with the given ID and client.
@@ -26,10 +26,10 @@ func newAnonymousChannel(
 ) *AnonymousChannel {
 	ctx, ctxCancel := context.WithCancelCause(ctx)
 	return &AnonymousChannel{
-		id:            id,
-		ClientChannel: ClientChannel{name: strconv.Itoa(id), client: c},
-		ctx:           ctx,
-		ctxCancel:     ctxCancel,
+		id:        id,
+		client:    c,
+		ctx:       ctx,
+		ctxCancel: ctxCancel,
 	}
 }
 
@@ -62,7 +62,7 @@ func (ch *AnonymousChannel) Once(eventName string, handler any) *AnonymousChanne
 func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
 	c := ch.client
 	if c == nil {
-		return ChannelClosedError{Channel: ch.name}
+		return ChannelClosedError{Channel: strconv.Itoa(ch.id)}
 	}
 	_, err := checkEventName(arguments)
 	if err != nil {
@@ -79,7 +79,7 @@ func (ch *AnonymousChannel) Request(
 ) (any, error) {
 	c := ch.client
 	if c == nil {
-		return nil, ChannelClosedError{Channel: ch.name}
+		return nil, ChannelClosedError{Channel: strconv.Itoa(ch.id)}
 	}
 	eventName, err := checkEventName(arguments)
 	if err != nil {
@@ -124,7 +124,6 @@ func (ch *AnonymousChannel) closeDetached(cause error) {
 	ch.client = nil
 	ch.ctxCancel(cause)
 }
-
 
 // Abort sends an abort message to the remote end with the provided reason and
 // closes this anonymous channel. If err is nil, it defaults to context.Canceled.

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -2,7 +2,6 @@ package wrapper
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 )
 
@@ -93,16 +92,17 @@ func (ch *AnonymousChannel) Request(
 // context. It does NOT send an abort message to the remote end; use Abort for
 // that. Close is idempotent and safe to call multiple times.
 func (ch *AnonymousChannel) Close() error {
-	return ch.closeWithCause(context.Canceled)
+	ch.closeWithCause(context.Canceled)
+	return nil
 }
 
 // closeWithCause closes the anonymous channel with a specific cause. This is
 // used internally when the connection closes or when an abort is received from
 // the remote end; it does not send an abort message.
-func (ch *AnonymousChannel) closeWithCause(cause error) error {
+func (ch *AnonymousChannel) closeWithCause(cause error) {
 	c := ch.client
 	if c == nil {
-		return nil // already closed
+		return // already closed
 	}
 	ch.client = nil
 	c.handlersMu.Lock()
@@ -113,7 +113,6 @@ func (ch *AnonymousChannel) closeWithCause(cause error) error {
 	c.connReqMu.Lock()
 	delete(c.anonChans, ch.id)
 	c.connReqMu.Unlock()
-	return nil
 }
 
 // Abort sends an abort message to the remote end with the provided reason and
@@ -123,13 +122,7 @@ func (ch *AnonymousChannel) Abort(err error) error {
 	if c == nil {
 		return nil // already closed
 	}
-	if err == nil {
-		err = context.Canceled
-	}
-	if sendErr := c.sendAnonCancel(ch.ctx, ch.id, err); sendErr != nil {
-		return fmt.Errorf("sending cancellation: %w", sendErr)
-	}
-	return nil
+	return c.sendAnonCancel(ch.ctx, ch.id, err)
 }
 
 // Context returns a context that is cancelled when this anonymous channel is

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -3,7 +3,6 @@ package wrapper
 import (
 	"context"
 	"fmt"
-	"sync"
 )
 
 // AnonymousChannel is a request-scoped channel created when a handler returns
@@ -11,7 +10,6 @@ import (
 // multi-message patterns over a single WebSocket connection.
 type AnonymousChannel struct {
 	ClientChannel // inherits name (channel ID string) and Name()
-	mu            sync.RWMutex
 	ctx           context.Context
 	ctxCancel     context.CancelCauseFunc
 }
@@ -19,11 +17,7 @@ type AnonymousChannel struct {
 // newAnonymousChannel creates an AnonymousChannel with the given ID and client.
 // The channel's context is derived from the client connection context so it is
 // automatically cancelled when the connection closes.
-func newAnonymousChannel(id string, c *Client) *AnonymousChannel {
-	c.connReqMu.Lock()
-	connCtx := c.ctx
-	c.connReqMu.Unlock()
-
+func newAnonymousChannel(connCtx context.Context, id string, c *Client) *AnonymousChannel {
 	ctx, ctxCancel := context.WithCancelCause(connCtx)
 	return &AnonymousChannel{
 		ClientChannel: ClientChannel{name: id, client: c},
@@ -35,9 +29,7 @@ func newAnonymousChannel(id string, c *Client) *AnonymousChannel {
 // On adds an event handler for the specified event on this anonymous channel.
 // See ClientChannel.On for handler signature details.
 func (ch *AnonymousChannel) On(eventName string, handler any) *AnonymousChannel {
-	ch.mu.RLock()
 	c := ch.client
-	ch.mu.RUnlock()
 	if c == nil {
 		return ch // channel closed; do nothing
 	}
@@ -48,9 +40,7 @@ func (ch *AnonymousChannel) On(eventName string, handler any) *AnonymousChannel 
 // Once adds a one-time event handler for the specified event on this anonymous
 // channel. See ClientChannel.On for handler signature details.
 func (ch *AnonymousChannel) Once(eventName string, handler any) *AnonymousChannel {
-	ch.mu.RLock()
 	c := ch.client
-	ch.mu.RUnlock()
 	if c == nil {
 		return ch // channel closed; do nothing
 	}
@@ -62,9 +52,7 @@ func (ch *AnonymousChannel) Once(eventName string, handler any) *AnonymousChanne
 // the event name string. Returns an error if the channel is closed or if the
 // message could not be sent.
 func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
-	ch.mu.RLock()
 	c := ch.client
-	ch.mu.RUnlock()
 	if c == nil {
 		return ChannelClosedError{Channel: ch.name}
 	}
@@ -81,9 +69,7 @@ func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
 func (ch *AnonymousChannel) Request(
 	ctx context.Context, arguments ...any,
 ) (any, error) {
-	ch.mu.RLock()
 	c := ch.client
-	ch.mu.RUnlock()
 	if c == nil {
 		return nil, ChannelClosedError{Channel: ch.name}
 	}
@@ -99,14 +85,11 @@ func (ch *AnonymousChannel) Request(
 // context. It does NOT send an abort message to the remote end; use Abort for
 // that. Close is idempotent and safe to call multiple times.
 func (ch *AnonymousChannel) Close() error {
-	ch.mu.Lock()
 	c := ch.client
 	if c == nil {
-		ch.mu.Unlock()
 		return nil // already closed
 	}
 	ch.client = nil
-	ch.mu.Unlock()
 
 	ch.ctxCancel(context.Canceled)
 
@@ -114,9 +97,9 @@ func (ch *AnonymousChannel) Close() error {
 	closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
 	c.handlersMu.Unlock()
 
-	c.anonChansMu.Lock()
+	c.connReqMu.Lock()
 	delete(c.anonChans, ch.name)
-	c.anonChansMu.Unlock()
+	c.connReqMu.Unlock()
 
 	return nil
 }
@@ -125,14 +108,11 @@ func (ch *AnonymousChannel) Close() error {
 // used internally when the connection closes or when an abort is received from
 // the remote end; it does not send an abort message.
 func (ch *AnonymousChannel) closeWithCause(cause error) {
-	ch.mu.Lock()
 	c := ch.client
 	if c == nil {
-		ch.mu.Unlock()
 		return // already closed
 	}
 	ch.client = nil
-	ch.mu.Unlock()
 
 	ch.ctxCancel(cause)
 
@@ -140,25 +120,23 @@ func (ch *AnonymousChannel) closeWithCause(cause error) {
 	closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
 	c.handlersMu.Unlock()
 
-	c.anonChansMu.Lock()
+	c.connReqMu.Lock()
 	delete(c.anonChans, ch.name)
-	c.anonChansMu.Unlock()
+	c.connReqMu.Unlock()
 }
 
 // Abort sends an abort message to the remote end and then closes the channel.
 // The provided error is sent as the abort reason. If err is nil, it defaults
 // to context.Canceled.
 func (ch *AnonymousChannel) Abort(err error) error {
-	ch.mu.RLock()
-	cl := ch.client
-	ch.mu.RUnlock()
-	if cl == nil {
+	c := ch.client
+	if c == nil {
 		return nil // already closed; nothing to abort
 	}
 	if err == nil {
 		err = context.Canceled
 	}
-	sendErr := cl.sendAnonCancel(context.Background(), ch.name, err)
+	sendErr := c.sendAnonCancel(context.Background(), ch.name, err)
 	ch.closeWithCause(err)
 	if sendErr != nil {
 		return fmt.Errorf("sending abort: %w", sendErr)

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -38,7 +38,7 @@ func newAnonymousChannel(
 func (ch *AnonymousChannel) On(eventName string, handler any) *AnonymousChannel {
 	c := ch.client
 	if c != nil {
-		key := handlerName{Channel: ch.name, Anonymous: true, Event: eventName}
+		key := handlerName{AnonymousChannel: ch.id, Event: eventName}
 		registerClientHandler(c, key, handler, false)
 	}
 	return ch
@@ -49,7 +49,7 @@ func (ch *AnonymousChannel) On(eventName string, handler any) *AnonymousChannel 
 func (ch *AnonymousChannel) Once(eventName string, handler any) *AnonymousChannel {
 	c := ch.client
 	if c != nil {
-		key := handlerName{Channel: ch.name, Anonymous: true, Event: eventName}
+		key := handlerName{AnonymousChannel: ch.id, Event: eventName}
 		registerClientHandler(c, key, handler, true)
 	}
 	return ch
@@ -106,7 +106,7 @@ func (ch *AnonymousChannel) closeWithCause(cause error) error {
 	}
 	ch.client = nil
 	c.handlersMu.Lock()
-	closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
+	closeHandlersForChannel("", ch.id, c.handlers, c.handlersOnce)
 	c.handlersMu.Unlock()
 
 	ch.ctxCancel(cause)

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -1,0 +1,174 @@
+package wrapper
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// AnonymousChannel is a request-scoped channel created when a handler returns
+// *AnonymousChannel in response to a request. It allows streaming or
+// multi-message patterns over a single WebSocket connection.
+type AnonymousChannel struct {
+	ClientChannel // inherits name (channel ID string) and Name()
+	mu            sync.RWMutex
+	ctx           context.Context
+	ctxCancel     context.CancelCauseFunc
+}
+
+// newAnonymousChannel creates an AnonymousChannel with the given ID and client.
+// The channel's context is derived from the client connection context so it is
+// automatically cancelled when the connection closes.
+func newAnonymousChannel(id string, c *Client) *AnonymousChannel {
+	c.connReqMu.Lock()
+	connCtx := c.ctx
+	c.connReqMu.Unlock()
+
+	ctx, ctxCancel := context.WithCancelCause(connCtx)
+	return &AnonymousChannel{
+		ClientChannel: ClientChannel{name: id, client: c},
+		ctx:           ctx,
+		ctxCancel:     ctxCancel,
+	}
+}
+
+// On adds an event handler for the specified event on this anonymous channel.
+// See ClientChannel.On for handler signature details.
+func (ch *AnonymousChannel) On(eventName string, handler any) *AnonymousChannel {
+	ch.mu.RLock()
+	c := ch.client
+	ch.mu.RUnlock()
+	if c == nil {
+		return ch // channel closed; do nothing
+	}
+	registerHandler(c, ch.name, eventName, true, handler, false)
+	return ch
+}
+
+// Once adds a one-time event handler for the specified event on this anonymous
+// channel. See ClientChannel.On for handler signature details.
+func (ch *AnonymousChannel) Once(eventName string, handler any) *AnonymousChannel {
+	ch.mu.RLock()
+	c := ch.client
+	ch.mu.RUnlock()
+	if c == nil {
+		return ch // channel closed; do nothing
+	}
+	registerHandler(c, ch.name, eventName, true, handler, true)
+	return ch
+}
+
+// Emit sends an event on this anonymous channel. The first argument must be
+// the event name string. Returns an error if the channel is closed or if the
+// message could not be sent.
+func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
+	ch.mu.RLock()
+	c := ch.client
+	ch.mu.RUnlock()
+	if c == nil {
+		return ChannelClosedError{Channel: ch.name}
+	}
+	eventName, err := checkEventName(arguments)
+	if err != nil {
+		return err
+	}
+	_ = eventName
+	return c.sendEvent(ctx, ch.name, true, arguments...)
+}
+
+// Request sends a request on this anonymous channel and returns the response.
+// The first argument must be the event name string.
+func (ch *AnonymousChannel) Request(
+	ctx context.Context, arguments ...any,
+) (any, error) {
+	ch.mu.RLock()
+	c := ch.client
+	ch.mu.RUnlock()
+	if c == nil {
+		return nil, ChannelClosedError{Channel: ch.name}
+	}
+	eventName, err := checkEventName(arguments)
+	if err != nil {
+		return nil, err
+	}
+	_ = eventName
+	return c.sendRequest(ctx, ch.name, true, arguments...)
+}
+
+// Close removes all event handlers for this anonymous channel and cancels its
+// context. It does NOT send an abort message to the remote end; use Abort for
+// that. Close is idempotent and safe to call multiple times.
+func (ch *AnonymousChannel) Close() error {
+	ch.mu.Lock()
+	c := ch.client
+	if c == nil {
+		ch.mu.Unlock()
+		return nil // already closed
+	}
+	ch.client = nil
+	ch.mu.Unlock()
+
+	ch.ctxCancel(context.Canceled)
+
+	c.handlersMu.Lock()
+	closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
+	c.handlersMu.Unlock()
+
+	c.anonChansMu.Lock()
+	delete(c.anonChans, ch.name)
+	c.anonChansMu.Unlock()
+
+	return nil
+}
+
+// closeWithCause closes the anonymous channel with a specific cause. This is
+// used internally when the connection closes or when an abort is received from
+// the remote end; it does not send an abort message.
+func (ch *AnonymousChannel) closeWithCause(cause error) {
+	ch.mu.Lock()
+	c := ch.client
+	if c == nil {
+		ch.mu.Unlock()
+		return // already closed
+	}
+	ch.client = nil
+	ch.mu.Unlock()
+
+	ch.ctxCancel(cause)
+
+	c.handlersMu.Lock()
+	closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
+	c.handlersMu.Unlock()
+
+	c.anonChansMu.Lock()
+	delete(c.anonChans, ch.name)
+	c.anonChansMu.Unlock()
+}
+
+// Abort sends an abort message to the remote end and then closes the channel.
+// The provided error is sent as the abort reason. If err is nil, it defaults
+// to context.Canceled.
+func (ch *AnonymousChannel) Abort(err error) error {
+	ch.mu.RLock()
+	cl := ch.client
+	ch.mu.RUnlock()
+	if cl == nil {
+		return nil // already closed; nothing to abort
+	}
+	if err == nil {
+		err = context.Canceled
+	}
+	sendErr := cl.sendAnonCancel(context.Background(), ch.name, err)
+	ch.closeWithCause(err)
+	if sendErr != nil {
+		return fmt.Errorf("sending abort: %w", sendErr)
+	}
+	return nil
+}
+
+// Context returns a context that is cancelled when this anonymous channel is
+// closed or aborted. The cancellation cause reflects the abort reason when the
+// remote end sends an abort message.
+func (ch *AnonymousChannel) Context() context.Context {
+	return ch.ctx
+}

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -17,8 +17,12 @@ type AnonymousChannel struct {
 // newAnonymousChannel creates an AnonymousChannel with the given ID and client.
 // The channel's context is derived from the client connection context so it is
 // automatically cancelled when the connection closes.
-func newAnonymousChannel(connCtx context.Context, id string, c *Client) *AnonymousChannel {
-	ctx, ctxCancel := context.WithCancelCause(connCtx)
+func newAnonymousChannel(
+	ctx context.Context,
+	id string,
+	c *Client,
+) *AnonymousChannel {
+	ctx, ctxCancel := context.WithCancelCause(ctx)
 	return &AnonymousChannel{
 		ClientChannel: ClientChannel{name: id, client: c},
 		ctx:           ctx,
@@ -30,10 +34,10 @@ func newAnonymousChannel(connCtx context.Context, id string, c *Client) *Anonymo
 // See ClientChannel.On for handler signature details.
 func (ch *AnonymousChannel) On(eventName string, handler any) *AnonymousChannel {
 	c := ch.client
-	if c == nil {
-		return ch // channel closed; do nothing
+	if c != nil {
+		key := handlerName{Channel: ch.name, Anonymous: true, Event: eventName}
+		registerClientHandler(c, key, handler, false)
 	}
-	registerHandler(c, ch.name, eventName, true, handler, false)
 	return ch
 }
 
@@ -41,14 +45,15 @@ func (ch *AnonymousChannel) On(eventName string, handler any) *AnonymousChannel 
 // channel. See ClientChannel.On for handler signature details.
 func (ch *AnonymousChannel) Once(eventName string, handler any) *AnonymousChannel {
 	c := ch.client
-	if c == nil {
-		return ch // channel closed; do nothing
+	if c != nil {
+		key := handlerName{Channel: ch.name, Anonymous: true, Event: eventName}
+		registerClientHandler(c, key, handler, true)
 	}
-	registerHandler(c, ch.name, eventName, true, handler, true)
 	return ch
 }
 
-// Emit sends an event on this anonymous channel. The first argument must be
+// Emit sends an event on this anonymous channel. The passed context can be used
+// to cancel writing the message to the client. The first argument must be
 // the event name string. Returns an error if the channel is closed or if the
 // message could not be sent.
 func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
@@ -56,16 +61,16 @@ func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
 	if c == nil {
 		return ChannelClosedError{Channel: ch.name}
 	}
-	eventName, err := checkEventName(arguments)
+	_, err := checkEventName(arguments)
 	if err != nil {
 		return err
 	}
-	_ = eventName
 	return c.sendEvent(ctx, ch.name, true, arguments...)
 }
 
 // Request sends a request on this anonymous channel and returns the response.
-// The first argument must be the event name string.
+// The passed context can be used to cancel the request. The first argument must
+// be the event name string.
 func (ch *AnonymousChannel) Request(
 	ctx context.Context, arguments ...any,
 ) (any, error) {
@@ -85,32 +90,16 @@ func (ch *AnonymousChannel) Request(
 // context. It does NOT send an abort message to the remote end; use Abort for
 // that. Close is idempotent and safe to call multiple times.
 func (ch *AnonymousChannel) Close() error {
-	c := ch.client
-	if c == nil {
-		return nil // already closed
-	}
-	ch.client = nil
-
-	ch.ctxCancel(context.Canceled)
-
-	c.handlersMu.Lock()
-	closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
-	c.handlersMu.Unlock()
-
-	c.connReqMu.Lock()
-	delete(c.anonChans, ch.name)
-	c.connReqMu.Unlock()
-
-	return nil
+	return ch.closeWithCause(context.Canceled)
 }
 
 // closeWithCause closes the anonymous channel with a specific cause. This is
 // used internally when the connection closes or when an abort is received from
 // the remote end; it does not send an abort message.
-func (ch *AnonymousChannel) closeWithCause(cause error) {
+func (ch *AnonymousChannel) closeWithCause(cause error) error {
 	c := ch.client
 	if c == nil {
-		return // already closed
+		return nil // already closed
 	}
 	ch.client = nil
 
@@ -123,6 +112,7 @@ func (ch *AnonymousChannel) closeWithCause(cause error) {
 	c.connReqMu.Lock()
 	delete(c.anonChans, ch.name)
 	c.connReqMu.Unlock()
+	return nil
 }
 
 // Abort sends an abort message to the remote end and then closes the channel.
@@ -131,17 +121,17 @@ func (ch *AnonymousChannel) closeWithCause(cause error) {
 func (ch *AnonymousChannel) Abort(err error) error {
 	c := ch.client
 	if c == nil {
-		return nil // already closed; nothing to abort
+		return nil // already closed
 	}
 	if err == nil {
 		err = context.Canceled
 	}
-	sendErr := c.sendAnonCancel(context.Background(), ch.name, err)
-	ch.closeWithCause(err)
+	sendErr := c.sendAnonCancel(ch.ctx, ch.name, err)
+	closeErr := ch.closeWithCause(err)
 	if sendErr != nil {
-		return fmt.Errorf("sending abort: %w", sendErr)
+		return fmt.Errorf("sending cancellation: %w", sendErr)
 	}
-	return nil
+	return closeErr
 }
 
 // Context returns a context that is cancelled when this anonymous channel is

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -2,34 +2,59 @@ package wrapper
 
 import (
 	"context"
+	"errors"
 	"strconv"
 )
+
+// errNotReady is returned by Emit and Request when called before the anonymous
+// channel has been returned by the handler.
+var errNotReady = errors.New("anonymous channel not yet ready")
 
 // AnonymousChannel is a request-scoped channel created when a handler returns
 // *AnonymousChannel in response to a request. It allows streaming or
 // multi-message patterns over a single WebSocket connection.
+//
+// Emit and Request are only available once the channel has been delivered to
+// the requestor (i.e. after the handler returns it). Before that point, both
+// methods return errNotReady. On and Once may be called freely at any time,
+// including inside the handler before the channel is returned.
 type AnonymousChannel struct {
 	id        int
 	client    *Client
 	ctx       context.Context
 	ctxCancel context.CancelCauseFunc
+	ready     bool // true once the creation response has been sent to the requestor
 }
 
 // newAnonymousChannel creates an AnonymousChannel with the given ID and client.
-// The channel's context is derived from the client connection context, so it is
-// automatically closed when the connection closes.
+// The channel's context is derived from ctx. Pass the client connection context
+// so the channel stays alive as long as the connection is open; when the
+// connection closes, closeWithCause is called explicitly via ch.ctxCancel.
 func newAnonymousChannel(
 	ctx context.Context,
+	reqCtx context.Context,
 	id int,
 	c *Client,
 ) *AnonymousChannel {
 	ctx, ctxCancel := context.WithCancelCause(ctx)
-	return &AnonymousChannel{
-		id:        id,
-		client:    c,
-		ctx:       ctx,
-		ctxCancel: ctxCancel,
+	anon := &AnonymousChannel{
+		id:     id,
+		client: c,
+		ctx:    ctx,
 	}
+	// When the caller's request context is cancelled, abort the anonymous
+	// channel.
+	stopReqCtxWatch := context.AfterFunc(reqCtx, func() {
+		_ = anon.Abort(context.Cause(reqCtx))
+	})
+	anon.ctxCancel = func(cause error) {
+		if stopReqCtxWatch != nil {
+			stopReqCtxWatch()
+			stopReqCtxWatch = nil
+		}
+		ctxCancel(cause)
+	}
+	return anon
 }
 
 // On adds an event handler for the specified event on this anonymous channel.
@@ -56,9 +81,12 @@ func (ch *AnonymousChannel) Once(eventName string, handler any) *AnonymousChanne
 
 // Emit sends an event on this anonymous channel. The passed context can be used
 // to cancel writing the message to the client. The first argument must be
-// the event name string. Returns an error if the channel is closed or if the
-// message could not be sent.
+// the event name string. Returns an error if the channel is not yet ready,
+// is closed, or if the message could not be sent.
 func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
+	if !ch.ready {
+		return errNotReady
+	}
 	c := ch.client
 	if c == nil {
 		return ChannelClosedError{Channel: strconv.Itoa(ch.id)}
@@ -72,10 +100,14 @@ func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
 
 // Request sends a request on this anonymous channel and returns the response.
 // The passed context can be used to cancel the request. The first argument must
-// be the event name string.
+// be the event name string. Returns an error if the channel is not yet ready
+// or is closed.
 func (ch *AnonymousChannel) Request(
 	ctx context.Context, arguments ...any,
 ) (any, error) {
+	if !ch.ready {
+		return nil, errNotReady
+	}
 	c := ch.client
 	if c == nil {
 		return nil, ChannelClosedError{Channel: strconv.Itoa(ch.id)}

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -3,13 +3,15 @@ package wrapper
 import (
 	"context"
 	"fmt"
+	"strconv"
 )
 
 // AnonymousChannel is a request-scoped channel created when a handler returns
 // *AnonymousChannel in response to a request. It allows streaming or
 // multi-message patterns over a single WebSocket connection.
 type AnonymousChannel struct {
-	ClientChannel // inherits name (channel ID string) and Name()
+	id            int
+	ClientChannel // inherits name (string form of id) and Name()
 	ctx           context.Context
 	ctxCancel     context.CancelCauseFunc
 }
@@ -19,12 +21,13 @@ type AnonymousChannel struct {
 // automatically cancelled when the connection closes.
 func newAnonymousChannel(
 	ctx context.Context,
-	id string,
+	id int,
 	c *Client,
 ) *AnonymousChannel {
 	ctx, ctxCancel := context.WithCancelCause(ctx)
 	return &AnonymousChannel{
-		ClientChannel: ClientChannel{name: id, client: c},
+		id:            id,
+		ClientChannel: ClientChannel{name: strconv.Itoa(id), client: c},
 		ctx:           ctx,
 		ctxCancel:     ctxCancel,
 	}
@@ -65,7 +68,7 @@ func (ch *AnonymousChannel) Emit(ctx context.Context, arguments ...any) error {
 	if err != nil {
 		return err
 	}
-	return c.sendEvent(ctx, ch.name, true, arguments...)
+	return c.sendEvent(ctx, "", ch.id, arguments...)
 }
 
 // Request sends a request on this anonymous channel and returns the response.
@@ -83,7 +86,7 @@ func (ch *AnonymousChannel) Request(
 		return nil, err
 	}
 	_ = eventName
-	return c.sendRequest(ctx, ch.name, true, arguments...)
+	return c.sendRequest(ctx, "", ch.id, arguments...)
 }
 
 // Close removes all event handlers for this anonymous channel and cancels its
@@ -108,7 +111,7 @@ func (ch *AnonymousChannel) closeWithCause(cause error) error {
 
 	ch.ctxCancel(cause)
 	c.connReqMu.Lock()
-	delete(c.anonChans, ch.name)
+	delete(c.anonChans, ch.id)
 	c.connReqMu.Unlock()
 	return nil
 }
@@ -133,7 +136,7 @@ func (ch *AnonymousChannel) Abort(err error) error {
 	if err == nil {
 		err = context.Canceled
 	}
-	sendErr := c.sendAnonCancel(ch.ctx, ch.name, err)
+	sendErr := c.sendAnonCancel(ch.ctx, ch.id, err)
 	closeErr := ch.closeWithCause(err)
 	if sendErr != nil {
 		return fmt.Errorf("sending cancellation: %w", sendErr)

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -126,8 +126,8 @@ func (ch *AnonymousChannel) closeDetached(cause error) {
 }
 
 
-// The provided error is sent as the abort reason. If err is nil, it defaults
-// to context.Canceled.
+// Abort sends an abort message to the remote end with the provided reason and
+// closes this anonymous channel. If err is nil, it defaults to context.Canceled.
 func (ch *AnonymousChannel) Abort(err error) error {
 	c := ch.client
 	if c == nil {
@@ -136,12 +136,10 @@ func (ch *AnonymousChannel) Abort(err error) error {
 	if err == nil {
 		err = context.Canceled
 	}
-	sendErr := c.sendAnonCancel(ch.ctx, ch.id, err)
-	closeErr := ch.closeWithCause(err)
-	if sendErr != nil {
+	if sendErr := c.sendAnonCancel(ch.ctx, ch.id, err); sendErr != nil {
 		return fmt.Errorf("sending cancellation: %w", sendErr)
 	}
-	return closeErr
+	return nil
 }
 
 // Context returns a context that is cancelled when this anonymous channel is

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -15,7 +15,7 @@ type AnonymousChannel struct {
 }
 
 // newAnonymousChannel creates an AnonymousChannel with the given ID and client.
-// The channel's context is derived from the client connection context so it is
+// The channel's context is derived from the client connection context, so it is
 // automatically cancelled when the connection closes.
 func newAnonymousChannel(
 	ctx context.Context,
@@ -102,20 +102,27 @@ func (ch *AnonymousChannel) closeWithCause(cause error) error {
 		return nil // already closed
 	}
 	ch.client = nil
-
-	ch.ctxCancel(cause)
-
 	c.handlersMu.Lock()
 	closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
 	c.handlersMu.Unlock()
 
+	ch.ctxCancel(cause)
 	c.connReqMu.Lock()
 	delete(c.anonChans, ch.name)
 	c.connReqMu.Unlock()
 	return nil
 }
 
-// Abort sends an abort message to the remote end and then closes the channel.
+// closeDetached closes the channel without acquiring any client locks. It is
+// intended for bulk-close paths (Bind, close) where the caller has already
+// removed all channels from anonChans and will remove their handlers under a
+// single handlersMu lock.
+func (ch *AnonymousChannel) closeDetached(cause error) {
+	ch.client = nil
+	ch.ctxCancel(cause)
+}
+
+
 // The provided error is sent as the abort reason. If err is nil, it defaults
 // to context.Canceled.
 func (ch *AnonymousChannel) Abort(err error) error {

--- a/anon_channel.go
+++ b/anon_channel.go
@@ -18,7 +18,7 @@ type AnonymousChannel struct {
 
 // newAnonymousChannel creates an AnonymousChannel with the given ID and client.
 // The channel's context is derived from the client connection context, so it is
-// automatically cancelled when the connection closes.
+// automatically closed when the connection closes.
 func newAnonymousChannel(
 	ctx context.Context,
 	id int,
@@ -114,15 +114,6 @@ func (ch *AnonymousChannel) closeWithCause(cause error) error {
 	delete(c.anonChans, ch.id)
 	c.connReqMu.Unlock()
 	return nil
-}
-
-// closeDetached closes the channel without acquiring any client locks. It is
-// intended for bulk-close paths (Bind, close) where the caller has already
-// removed all channels from anonChans and will remove their handlers under a
-// single handlersMu lock.
-func (ch *AnonymousChannel) closeDetached(cause error) {
-	ch.client = nil
-	ch.ctxCancel(cause)
 }
 
 // Abort sends an abort message to the remote end with the provided reason and

--- a/anon_channel_test.go
+++ b/anon_channel_test.go
@@ -1,0 +1,826 @@
+package wrapper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// ── anonChannelH type tests ───────────────────────────────────────────────────
+
+// TestAnonChannelH_UnmarshalString verifies that a JSON string is decoded as-is.
+func TestAnonChannelH_UnmarshalString(t *testing.T) {
+	var h anonChannelH
+	if err := json.Unmarshal([]byte(`"42"`), &h); err != nil {
+		t.Fatal(err)
+	}
+	if h != "42" {
+		t.Fatalf("expected \"42\", got %q", h)
+	}
+}
+
+// TestAnonChannelH_UnmarshalNumber verifies that a truthy JSON number maps to "1".
+func TestAnonChannelH_UnmarshalNumber(t *testing.T) {
+	var h anonChannelH
+	if err := json.Unmarshal([]byte(`1`), &h); err != nil {
+		t.Fatal(err)
+	}
+	if h != "1" {
+		t.Fatalf("expected \"1\", got %q", h)
+	}
+}
+
+// TestAnonChannelH_UnmarshalZero verifies that JSON 0 maps to "".
+func TestAnonChannelH_UnmarshalZero(t *testing.T) {
+	var h anonChannelH
+	if err := json.Unmarshal([]byte(`0`), &h); err != nil {
+		t.Fatal(err)
+	}
+	if h != "" {
+		t.Fatalf("expected empty string, got %q", h)
+	}
+}
+
+// ── Channel(ctx) factory tests ────────────────────────────────────────────────
+
+// TestChannelOutsideHandler verifies that Channel(ctx) returns nil when called
+// outside a request handler (no factory in context).
+func TestChannelOutsideHandler(t *testing.T) {
+	if ch := Channel(context.Background()); ch != nil {
+		t.Fatalf("expected nil outside handler, got %v", ch)
+	}
+}
+
+// TestChannelLazySingleton verifies that Channel(ctx) returns the same
+// *AnonymousChannel on repeated calls within the same handler context.
+func TestChannelLazySingleton(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var ch1, ch2 *AnonymousChannel
+	created := make(chan struct{})
+	server.On("getChannel", func(ctx context.Context) (*AnonymousChannel, error) {
+		ch1 = Channel(ctx)
+		ch2 = Channel(ctx) // second call — must return the same pointer
+		close(created)
+		return ch1, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"getChannel"`)},
+	})
+
+	select {
+	case <-created:
+	case <-time.After(time.Second):
+		t.Fatal("handler not called")
+	}
+
+	// Consume the creation response before checking
+	conn.waitWritten(t, time.Second)
+
+	if ch1 == nil {
+		t.Fatal("Channel(ctx) returned nil inside handler")
+	}
+	if ch1 != ch2 {
+		t.Fatal("Channel(ctx) returned different pointers on repeated calls")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// ── Go-as-handler: returning *AnonymousChannel ────────────────────────────────
+
+// TestHandlerReturnsAnonChannel verifies that when a handler returns
+// *AnonymousChannel, the server sends a creation response {i, h}.
+func TestHandlerReturnsAnonChannel(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		return Channel(ctx), nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+
+	resp := conn.waitWritten(t, time.Second)
+	if resp.RequestID == nil || *resp.RequestID != reqID {
+		t.Fatalf("expected creation response for request %d, got %+v", reqID, resp)
+	}
+	if resp.AnonymousChannel == "" {
+		t.Fatalf("expected non-empty h field, got %+v", resp)
+	}
+	if resp.ResponseData != nil || resp.ResponseError != nil {
+		t.Fatalf("creation response must not have d/e fields, got %+v", resp)
+	}
+	// Channel ID must equal strconv.Itoa(reqID)
+	expectedChanID := "1"
+	if string(resp.AnonymousChannel) != expectedChanID {
+		t.Fatalf("expected h=%q, got h=%q", expectedChanID, resp.AnonymousChannel)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestHandlerReturnsNilDoesNotSendCreation verifies that returning nil (or a
+// non-matching *AnonymousChannel) sends a normal response, not a creation response.
+func TestHandlerReturnsNilDoesNotSendCreation(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	server.On("noChannel", func(ctx context.Context) (*AnonymousChannel, error) {
+		// Deliberately ignore Channel(ctx) — return nil
+		return nil, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"noChannel"`)},
+	})
+
+	resp := conn.waitWritten(t, time.Second)
+	if resp.RequestID == nil || *resp.RequestID != reqID {
+		t.Fatalf("expected response for request %d, got %+v", reqID, resp)
+	}
+	// Must be a regular resolve (d: null), not a creation response (h field)
+	if resp.AnonymousChannel != "" {
+		t.Fatalf("expected no h field, got %+v", resp)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// ── Routing events/requests to anonymous channel handlers ────────────────────
+
+// TestAnonChannelEventRouted verifies that inbound {h, a} messages are routed
+// to handlers registered on the anonymous channel.
+func TestAnonChannelEventRouted(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	called := make(chan string, 1)
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		ch := Channel(ctx)
+		ch.On("data", func(v string) (string, error) {
+			called <- v
+			return "", nil
+		})
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	// Request that triggers creation
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+
+	// Send an event on the anonymous channel
+	conn.send(Message{
+		AnonymousChannel: "1",
+		Arguments:        []json.RawMessage{[]byte(`"data"`), []byte(`"hello"`)},
+	})
+
+	select {
+	case v := <-called:
+		if v != "hello" {
+			t.Fatalf("expected 'hello', got %q", v)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("anon channel event handler was not called")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonChannelRequestRouted verifies that inbound {i, h, a} sub-requests
+// are routed to handlers and a response is sent back.
+func TestAnonChannelRequestRouted(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		ch := Channel(ctx)
+		ch.On("compute", func(x int) (int, error) {
+			return x * 2, nil
+		})
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+
+	// Send a sub-request on the anonymous channel
+	subReqID := 2
+	conn.send(Message{
+		RequestID:        &subReqID,
+		AnonymousChannel: "1",
+		Arguments:        []json.RawMessage{[]byte(`"compute"`), []byte(`21`)},
+	})
+
+	resp := conn.waitWritten(t, time.Second)
+	if resp.RequestID == nil || *resp.RequestID != subReqID {
+		t.Fatalf("expected response for sub-request %d, got %+v", subReqID, resp)
+	}
+	if resp.ResponseData != 42 {
+		t.Fatalf("expected 42, got %v", resp.ResponseData)
+	}
+	// Response must NOT have h field
+	if resp.AnonymousChannel != "" {
+		t.Fatalf("sub-request response must not have h field, got %+v", resp)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonChannelInboundAbort verifies that an inbound {h, x} abort message
+// closes the local anonymous channel and cancels its context.
+func TestAnonChannelInboundAbort(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	ctxDone := make(chan error, 1)
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		ch := Channel(ctx)
+		go func() {
+			<-ch.Context().Done()
+			ctxDone <- context.Cause(ch.Context())
+		}()
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+
+	// Remote sends abort
+	conn.send(Message{
+		AnonymousChannel: "1",
+		ResponseJSError:  true,
+		CancelReason: map[string]any{
+			"message": "remote aborted",
+		},
+	})
+
+	select {
+	case cause := <-ctxDone:
+		if cause == nil || cause.Error() != "remote aborted" {
+			t.Fatalf("expected 'remote aborted', got %v", cause)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("channel context was not cancelled after inbound abort")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// ── AnonymousChannel.Abort() and Close() ─────────────────────────────────────
+
+// TestAnonChannelAbort verifies that Abort sends {h, x} and cancels the context.
+func TestAnonChannelAbort(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var capturedCh *AnonymousChannel
+	ready := make(chan struct{})
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		capturedCh = Channel(ctx)
+		close(ready)
+		return capturedCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+
+	<-ready
+
+	abortErr := errors.New("server aborted")
+	if err := capturedCh.Abort(abortErr); err != nil {
+		t.Fatalf("Abort returned error: %v", err)
+	}
+
+	// Expect abort message
+	abort := conn.waitWritten(t, time.Second)
+	if abort.AnonymousChannel != "1" {
+		t.Fatalf("expected h='1', got %+v", abort)
+	}
+	if !abort.ResponseJSError {
+		t.Fatal("expected abort encoded as JS error")
+	}
+	expected := map[string]any{"message": "server aborted"}
+	if !reflect.DeepEqual(expected, abort.CancelReason) {
+		t.Fatalf("expected cancel reason %v, got %v", expected, abort.CancelReason)
+	}
+	if abort.RequestID != nil {
+		t.Fatalf("abort must not have i field, got %+v", abort)
+	}
+
+	// Context must be cancelled
+	select {
+	case <-capturedCh.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("channel context was not cancelled after Abort")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonChannelClose verifies that Close cancels the context without sending
+// any abort message to the remote end.
+func TestAnonChannelClose(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var capturedCh *AnonymousChannel
+	ready := make(chan struct{})
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		capturedCh = Channel(ctx)
+		close(ready)
+		return capturedCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+
+	<-ready
+
+	if err := capturedCh.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	// No abort message should be sent
+	select {
+	case msg := <-conn.writeCh:
+		t.Fatalf("unexpected message after Close: %+v", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Context must be cancelled
+	select {
+	case <-capturedCh.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("channel context was not cancelled after Close")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonChannelCloseIdempotent verifies that calling Close multiple times is
+// safe and returns nil on subsequent calls.
+func TestAnonChannelCloseIdempotent(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var capturedCh *AnonymousChannel
+	ready := make(chan struct{})
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		capturedCh = Channel(ctx)
+		close(ready)
+		return capturedCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second)
+	<-ready
+
+	if err := capturedCh.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := capturedCh.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonChannelEmitAfterClose verifies that Emit on a closed channel returns
+// ChannelClosedError.
+func TestAnonChannelEmitAfterClose(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var capturedCh *AnonymousChannel
+	ready := make(chan struct{})
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		capturedCh = Channel(ctx)
+		close(ready)
+		return capturedCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second)
+	<-ready
+
+	capturedCh.Close()
+
+	err := capturedCh.Emit(context.Background(), "event")
+	if err == nil {
+		t.Fatal("expected ChannelClosedError, got nil")
+	}
+	var closedErr ChannelClosedError
+	if !errors.As(err, &closedErr) {
+		t.Fatalf("expected ChannelClosedError, got %T: %v", err, err)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonChannelEmitSendsCorrectMessage verifies that Emit on an open
+// anonymous channel sends {h, a} (no c field, no i field).
+func TestAnonChannelEmitSendsCorrectMessage(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var capturedCh *AnonymousChannel
+	ready := make(chan struct{})
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		capturedCh = Channel(ctx)
+		close(ready)
+		return capturedCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+	<-ready
+
+	if err := capturedCh.Emit(context.Background(), "tick", 42); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	msg := conn.waitWritten(t, time.Second)
+	if msg.Channel != "" {
+		t.Fatalf("expected no c field, got %+v", msg)
+	}
+	if msg.AnonymousChannel != "1" {
+		t.Fatalf("expected h='1', got %+v", msg)
+	}
+	if msg.RequestID != nil {
+		t.Fatalf("event must not have i field, got %+v", msg)
+	}
+	if len(msg.Arguments) < 2 {
+		t.Fatalf("expected at least 2 arguments (event+payload), got %+v", msg)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// ── Connection close cleans up anonymous channels ────────────────────────────
+
+// TestConnectionCloseAbortsAnonChannels verifies that closing the connection
+// cancels all open anonymous channel contexts.
+func TestConnectionCloseAbortsAnonChannels(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	ctxDone := make(chan struct{}, 1)
+	var capturedCh *AnonymousChannel
+	ready := make(chan struct{})
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		capturedCh = Channel(ctx)
+		close(ready)
+		return capturedCh, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second)
+	<-ready
+
+	go func() {
+		<-capturedCh.Context().Done()
+		ctxDone <- struct{}{}
+	}()
+
+	conn.Close(StatusNormalClosure, "done")
+
+	select {
+	case <-ctxDone:
+	case <-time.After(time.Second):
+		t.Fatal("anon channel context not cancelled after connection close")
+	}
+}
+
+// ── Unknown anonymous channel traffic ────────────────────────────────────────
+
+// TestUnknownAnonChannelEventSendsCancel verifies that traffic on an unknown
+// anonymous channel triggers a sendAnonCancel message.
+func TestUnknownAnonChannelEventSendsCancel(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send event to a channel ID that was never created
+	conn.send(Message{
+		AnonymousChannel: "99",
+		Arguments:        []json.RawMessage{[]byte(`"data"`), []byte(`"hello"`)},
+	})
+
+	msg := conn.waitWritten(t, time.Second)
+	if msg.AnonymousChannel != "99" {
+		t.Fatalf("expected h='99', got %+v", msg)
+	}
+	if msg.CancelReason == nil {
+		t.Fatalf("expected cancel reason, got %+v", msg)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestUnknownAnonChannelRequestSendsCancelAndReject verifies that a sub-request
+// on an unknown anonymous channel triggers both a cancel AND a reject response.
+func TestUnknownAnonChannelRequestSendsCancelAndReject(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	subReqID := 5
+	conn.send(Message{
+		RequestID:        &subReqID,
+		AnonymousChannel: "99",
+		Arguments:        []json.RawMessage{[]byte(`"compute"`)},
+	})
+
+	// Expect two outbound messages: cancel + reject (order may vary)
+	msg1 := conn.waitWritten(t, time.Second)
+	msg2 := conn.waitWritten(t, time.Second)
+
+	// Identify cancel vs reject
+	var cancelMsg, rejectMsg Message
+	if msg1.AnonymousChannel != "" {
+		cancelMsg, rejectMsg = msg1, msg2
+	} else {
+		cancelMsg, rejectMsg = msg2, msg1
+	}
+
+	if cancelMsg.AnonymousChannel != "99" {
+		t.Fatalf("expected cancel with h='99', got %+v", cancelMsg)
+	}
+	if rejectMsg.RequestID == nil || *rejectMsg.RequestID != subReqID {
+		t.Fatalf("expected reject for sub-request %d, got %+v", subReqID, rejectMsg)
+	}
+	if rejectMsg.ResponseError == nil {
+		t.Fatalf("expected reject with error, got %+v", rejectMsg)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// ── Go-as-requestor: receiving a creation response ────────────────────────────
+
+// TestGoAsRequestorReceivesAnonChannel verifies that when Go sends a request
+// and the remote responds with {i, h: 1}, sendRequest returns *AnonymousChannel.
+func TestGoAsRequestorReceivesAnonChannel(t *testing.T) {
+	client := NewClient(nil)
+	conn := newMockConn()
+	client.Bind(conn)
+
+	result := make(chan any, 1)
+	go func() {
+		resp, err := client.Request(context.Background(), "streamData")
+		if err != nil {
+			result <- err
+			return
+		}
+		result <- resp
+	}()
+
+	// Wait for the outbound request
+	req := conn.waitWritten(t, time.Second)
+	if req.RequestID == nil {
+		t.Fatalf("expected request with ID, got %+v", req)
+	}
+
+	// JS responds with {i: reqID, h: 1}
+	conn.send(Message{
+		RequestID:        req.RequestID,
+		AnonymousChannel: "1", // custom unmarshaller maps JS's h:1 to "1"
+	})
+
+	select {
+	case v := <-result:
+		if err, ok := v.(error); ok {
+			t.Fatalf("expected *AnonymousChannel, got error: %v", err)
+		}
+		anon, ok := v.(*AnonymousChannel)
+		if !ok {
+			t.Fatalf("expected *AnonymousChannel, got %T", v)
+		}
+		if anon == nil {
+			t.Fatal("expected non-nil *AnonymousChannel")
+		}
+		// Channel ID should be the string form of the request ID
+		if anon.Name() != "1" {
+			t.Fatalf("expected Name()='1', got %q", anon.Name())
+		}
+		_ = anon
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for anonymous channel result")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestGoAsRequestorEmitsOnAnonChannel verifies that after receiving a creation
+// response, Go can send events on the anonymous channel.
+func TestGoAsRequestorEmitsOnAnonChannel(t *testing.T) {
+	client := NewClient(nil)
+	conn := newMockConn()
+	client.Bind(conn)
+
+	result := make(chan *AnonymousChannel, 1)
+	go func() {
+		resp, err := client.Request(context.Background(), "stream")
+		if err != nil {
+			return
+		}
+		anon, _ := resp.(*AnonymousChannel)
+		result <- anon
+	}()
+
+	// Receive outbound request and respond with creation response
+	req := conn.waitWritten(t, time.Second)
+	conn.send(Message{
+		RequestID:        req.RequestID,
+		AnonymousChannel: "1",
+	})
+
+	var anon *AnonymousChannel
+	select {
+	case anon = <-result:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for anonymous channel")
+	}
+
+	// Now emit an event on the channel
+	if err := anon.Emit(context.Background(), "data", "payload"); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	emitted := conn.waitWritten(t, time.Second)
+	if emitted.AnonymousChannel != anonChannelH(anon.Name()) {
+		t.Fatalf("expected h=%q, got %+v", anon.Name(), emitted)
+	}
+	if emitted.Channel != "" {
+		t.Fatalf("event must not have c field, got %+v", emitted)
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestGoAsRequestorReceivesAnonChannelEvent verifies that when the remote sends
+// an event on the anonymous channel, the registered handler is called.
+func TestGoAsRequestorReceivesAnonChannelEvent(t *testing.T) {
+	client := NewClient(nil)
+	conn := newMockConn()
+	client.Bind(conn)
+
+	called := make(chan string, 1)
+	result := make(chan *AnonymousChannel, 1)
+	go func() {
+		resp, err := client.Request(context.Background(), "stream")
+		if err != nil {
+			return
+		}
+		anon, _ := resp.(*AnonymousChannel)
+		if anon == nil {
+			return
+		}
+		anon.On("data", func(v string) (string, error) {
+			called <- v
+			return "", nil
+		})
+		result <- anon
+	}()
+
+	req := conn.waitWritten(t, time.Second)
+	conn.send(Message{
+		RequestID:        req.RequestID,
+		AnonymousChannel: "1",
+	})
+
+	select {
+	case <-result:
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	// Remote sends event on the channel
+	conn.send(Message{
+		AnonymousChannel: anonChannelH(anon_name(req.RequestID)),
+		Arguments:        []json.RawMessage{[]byte(`"data"`), []byte(`"world"`)},
+	})
+
+	select {
+	case v := <-called:
+		if v != "world" {
+			t.Fatalf("expected 'world', got %q", v)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event handler not called")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// anon_name returns the expected channel ID for a given request ID pointer.
+func anon_name(id *int) string {
+	if id == nil {
+		return ""
+	}
+	return string(rune('0' + *id)) // works for single-digit IDs in tests
+}

--- a/anon_channel_test.go
+++ b/anon_channel_test.go
@@ -724,10 +724,6 @@ func TestGoAsRequestorReceivesAnonChannel(t *testing.T) {
 		if anon == nil {
 			t.Fatal("expected non-nil *AnonymousChannel")
 		}
-		// Channel ID should be the string form of the request ID
-		if anon.Name() != "1" {
-			t.Fatalf("expected Name()='1', got %q", anon.Name())
-		}
 		_ = anon
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for anonymous channel result")

--- a/anon_channel_test.go
+++ b/anon_channel_test.go
@@ -9,41 +9,6 @@ import (
 	"time"
 )
 
-// ── anonChannelH type tests ───────────────────────────────────────────────────
-
-// TestAnonChannelH_UnmarshalString verifies that a JSON string is decoded as-is.
-func TestAnonChannelH_UnmarshalString(t *testing.T) {
-	var h anonChannelH
-	if err := json.Unmarshal([]byte(`"42"`), &h); err != nil {
-		t.Fatal(err)
-	}
-	if h != "42" {
-		t.Fatalf("expected \"42\", got %q", h)
-	}
-}
-
-// TestAnonChannelH_UnmarshalNumber verifies that a truthy JSON number maps to "1".
-func TestAnonChannelH_UnmarshalNumber(t *testing.T) {
-	var h anonChannelH
-	if err := json.Unmarshal([]byte(`1`), &h); err != nil {
-		t.Fatal(err)
-	}
-	if h != "1" {
-		t.Fatalf("expected \"1\", got %q", h)
-	}
-}
-
-// TestAnonChannelH_UnmarshalZero verifies that JSON 0 maps to "".
-func TestAnonChannelH_UnmarshalZero(t *testing.T) {
-	var h anonChannelH
-	if err := json.Unmarshal([]byte(`0`), &h); err != nil {
-		t.Fatal(err)
-	}
-	if h != "" {
-		t.Fatalf("expected empty string, got %q", h)
-	}
-}
-
 // ── Channel(ctx) factory tests ────────────────────────────────────────────────
 
 // TestChannelOutsideHandler verifies that Channel(ctx) returns nil when called
@@ -124,16 +89,14 @@ func TestHandlerReturnsAnonChannel(t *testing.T) {
 	if resp.RequestID == nil || *resp.RequestID != reqID {
 		t.Fatalf("expected creation response for request %d, got %+v", reqID, resp)
 	}
-	if resp.AnonymousChannel == "" {
+	if resp.AnonymousChannel == 0 {
 		t.Fatalf("expected non-empty h field, got %+v", resp)
 	}
 	if resp.ResponseData != nil || resp.ResponseError != nil {
 		t.Fatalf("creation response must not have d/e fields, got %+v", resp)
 	}
-	// Channel ID must equal strconv.Itoa(reqID)
-	expectedChanID := "1"
-	if string(resp.AnonymousChannel) != expectedChanID {
-		t.Fatalf("expected h=%q, got h=%q", expectedChanID, resp.AnonymousChannel)
+	if resp.AnonymousChannel != 1 {
+		t.Fatalf("expected h=1, got h=%d", resp.AnonymousChannel)
 	}
 
 	conn.Close(StatusNormalClosure, "done")
@@ -165,7 +128,7 @@ func TestHandlerReturnsNilDoesNotSendCreation(t *testing.T) {
 		t.Fatalf("expected response for request %d, got %+v", reqID, resp)
 	}
 	// Must be a regular resolve (d: null), not a creation response (h field)
-	if resp.AnonymousChannel != "" {
+	if resp.AnonymousChannel != 0 {
 		t.Fatalf("expected no h field, got %+v", resp)
 	}
 
@@ -204,7 +167,7 @@ func TestAnonChannelEventRouted(t *testing.T) {
 
 	// Send an event on the anonymous channel
 	conn.send(Message{
-		AnonymousChannel: "1",
+		AnonymousChannel: 1,
 		Arguments:        []json.RawMessage{[]byte(`"data"`), []byte(`"hello"`)},
 	})
 
@@ -249,7 +212,7 @@ func TestAnonChannelRequestRouted(t *testing.T) {
 	subReqID := 2
 	conn.send(Message{
 		RequestID:        &subReqID,
-		AnonymousChannel: "1",
+		AnonymousChannel: 1,
 		Arguments:        []json.RawMessage{[]byte(`"compute"`), []byte(`21`)},
 	})
 
@@ -261,7 +224,7 @@ func TestAnonChannelRequestRouted(t *testing.T) {
 		t.Fatalf("expected 42, got %v", resp.ResponseData)
 	}
 	// Response must NOT have h field
-	if resp.AnonymousChannel != "" {
+	if resp.AnonymousChannel != 0 {
 		t.Fatalf("sub-request response must not have h field, got %+v", resp)
 	}
 
@@ -297,7 +260,7 @@ func TestAnonChannelInboundAbort(t *testing.T) {
 
 	// Remote sends abort
 	conn.send(Message{
-		AnonymousChannel: "1",
+		AnonymousChannel: 1,
 		ResponseJSError:  true,
 		CancelReason: map[string]any{
 			"message": "remote aborted",
@@ -351,7 +314,7 @@ func TestAnonChannelAbort(t *testing.T) {
 
 	// Expect abort message
 	abort := conn.waitWritten(t, time.Second)
-	if abort.AnonymousChannel != "1" {
+	if abort.AnonymousChannel != 1 {
 		t.Fatalf("expected h='1', got %+v", abort)
 	}
 	if !abort.ResponseJSError {
@@ -533,7 +496,7 @@ func TestAnonChannelEmitSendsCorrectMessage(t *testing.T) {
 	if msg.Channel != "" {
 		t.Fatalf("expected no c field, got %+v", msg)
 	}
-	if msg.AnonymousChannel != "1" {
+	if msg.AnonymousChannel != 1 {
 		t.Fatalf("expected h='1', got %+v", msg)
 	}
 	if msg.RequestID != nil {
@@ -603,12 +566,12 @@ func TestUnknownAnonChannelEventSendsCancel(t *testing.T) {
 
 	// Send event to a channel ID that was never created
 	conn.send(Message{
-		AnonymousChannel: "99",
+		AnonymousChannel: 99,
 		Arguments:        []json.RawMessage{[]byte(`"data"`), []byte(`"hello"`)},
 	})
 
 	msg := conn.waitWritten(t, time.Second)
-	if msg.AnonymousChannel != "99" {
+	if msg.AnonymousChannel != 99 {
 		t.Fatalf("expected h='99', got %+v", msg)
 	}
 	if msg.CancelReason == nil {
@@ -631,7 +594,7 @@ func TestUnknownAnonChannelRequestSendsCancelAndReject(t *testing.T) {
 	subReqID := 5
 	conn.send(Message{
 		RequestID:        &subReqID,
-		AnonymousChannel: "99",
+		AnonymousChannel: 99,
 		Arguments:        []json.RawMessage{[]byte(`"compute"`)},
 	})
 
@@ -641,13 +604,13 @@ func TestUnknownAnonChannelRequestSendsCancelAndReject(t *testing.T) {
 
 	// Identify cancel vs reject
 	var cancelMsg, rejectMsg Message
-	if msg1.AnonymousChannel != "" {
+	if msg1.AnonymousChannel != 0 {
 		cancelMsg, rejectMsg = msg1, msg2
 	} else {
 		cancelMsg, rejectMsg = msg2, msg1
 	}
 
-	if cancelMsg.AnonymousChannel != "99" {
+	if cancelMsg.AnonymousChannel != 99 {
 		t.Fatalf("expected cancel with h='99', got %+v", cancelMsg)
 	}
 	if rejectMsg.RequestID == nil || *rejectMsg.RequestID != subReqID {
@@ -688,7 +651,7 @@ func TestGoAsRequestorReceivesAnonChannel(t *testing.T) {
 	// JS responds with {i: reqID, h: 1}
 	conn.send(Message{
 		RequestID:        req.RequestID,
-		AnonymousChannel: "1", // custom unmarshaller maps JS's h:1 to "1"
+		AnonymousChannel: 1,
 	})
 
 	select {
@@ -736,7 +699,7 @@ func TestGoAsRequestorEmitsOnAnonChannel(t *testing.T) {
 	req := conn.waitWritten(t, time.Second)
 	conn.send(Message{
 		RequestID:        req.RequestID,
-		AnonymousChannel: "1",
+		AnonymousChannel: 1,
 	})
 
 	var anon *AnonymousChannel
@@ -752,8 +715,8 @@ func TestGoAsRequestorEmitsOnAnonChannel(t *testing.T) {
 	}
 
 	emitted := conn.waitWritten(t, time.Second)
-	if emitted.AnonymousChannel != anonChannelH(anon.Name()) {
-		t.Fatalf("expected h=%q, got %+v", anon.Name(), emitted)
+	if emitted.AnonymousChannel == 0 {
+		t.Fatalf("expected non-zero h field, got %+v", emitted)
 	}
 	if emitted.Channel != "" {
 		t.Fatalf("event must not have c field, got %+v", emitted)
@@ -790,7 +753,7 @@ func TestGoAsRequestorReceivesAnonChannelEvent(t *testing.T) {
 	req := conn.waitWritten(t, time.Second)
 	conn.send(Message{
 		RequestID:        req.RequestID,
-		AnonymousChannel: "1",
+		AnonymousChannel: 1,
 	})
 
 	select {
@@ -801,7 +764,7 @@ func TestGoAsRequestorReceivesAnonChannelEvent(t *testing.T) {
 
 	// Remote sends event on the channel
 	conn.send(Message{
-		AnonymousChannel: anonChannelH(anon_name(req.RequestID)),
+		AnonymousChannel: *req.RequestID,
 		Arguments:        []json.RawMessage{[]byte(`"data"`), []byte(`"world"`)},
 	})
 
@@ -815,12 +778,4 @@ func TestGoAsRequestorReceivesAnonChannelEvent(t *testing.T) {
 	}
 
 	conn.Close(StatusNormalClosure, "done")
-}
-
-// anon_name returns the expected channel ID for a given request ID pointer.
-func anon_name(id *int) string {
-	if id == nil {
-		return ""
-	}
-	return string(rune('0' + *id)) // works for single-digit IDs in tests
 }

--- a/anon_channel_test.go
+++ b/anon_channel_test.go
@@ -480,6 +480,79 @@ func TestAnonChannelCloseIdempotent(t *testing.T) {
 	conn.Close(StatusNormalClosure, "done")
 }
 
+// TestAnonChannelEmitBeforeReady verifies that Emit called inside the handler
+// (before the channel is returned) returns errNotReady.
+func TestAnonChannelEmitBeforeReady(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	emitErr := make(chan error, 1)
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		ch := Channel(ctx)
+		emitErr <- ch.Emit(ctx, "premature")
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+
+	select {
+	case err := <-emitErr:
+		if !errors.Is(err, errNotReady) {
+			t.Fatalf("expected errNotReady, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handler not called")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestAnonChannelRequestBeforeReady verifies that Request called inside the
+// handler (before the channel is returned) returns errNotReady.
+func TestAnonChannelRequestBeforeReady(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	requestErr := make(chan error, 1)
+	server.On("stream", func(ctx context.Context) (*AnonymousChannel, error) {
+		ch := Channel(ctx)
+		_, err := ch.Request(ctx, "premature")
+		requestErr <- err
+		return ch, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"stream"`)},
+	})
+	conn.waitWritten(t, time.Second) // consume creation response
+
+	select {
+	case err := <-requestErr:
+		if !errors.Is(err, errNotReady) {
+			t.Fatalf("expected errNotReady, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handler not called")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
 // TestAnonChannelEmitAfterClose verifies that Emit on a closed channel returns
 // ChannelClosedError.
 func TestAnonChannelEmitAfterClose(t *testing.T) {
@@ -832,4 +905,127 @@ func TestGoAsRequestorReceivesAnonChannelEvent(t *testing.T) {
 	}
 
 	conn.Close(StatusNormalClosure, "done")
+}
+
+// ── Request context cancellation aborts outbound anonymous channel ─────────────
+
+// TestOutboundRequestCtxCancelAbortsAnonChannel verifies that when the context
+// passed to Request is cancelled after the remote responds with an anonymous
+// channel, an abort message {h, x} is sent to the remote and the channel's
+// context is cancelled with the same cause.
+func TestOutboundRequestCtxCancelAbortsAnonChannel(t *testing.T) {
+	client := NewClient(nil)
+	conn := newMockConn()
+	client.Bind(conn)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	result := make(chan *AnonymousChannel, 1)
+	go func() {
+		resp, err := client.Request(ctx, "stream")
+		if err != nil {
+			return
+		}
+		result <- resp.(*AnonymousChannel)
+	}()
+
+	// Wait for the outbound request and respond with a creation response.
+	req := conn.waitWritten(t, time.Second)
+	if req.RequestID == nil {
+		t.Fatalf("expected outbound request, got %+v", req)
+	}
+	conn.send(Message{RequestID: req.RequestID, AnonymousChannel: 1})
+
+	var anon *AnonymousChannel
+	select {
+	case anon = <-result:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for anonymous channel")
+	}
+
+	// Cancel the request context.
+	abortCause := errors.New("caller cancelled")
+	cancel(abortCause)
+
+	// An abort message must be sent to the remote.
+	abort := conn.waitWritten(t, time.Second)
+	if abort.AnonymousChannel != *req.RequestID {
+		t.Fatalf("expected abort for channel %d, got %+v", *req.RequestID, abort)
+	}
+	if !abort.ResponseJSError {
+		t.Fatal("expected abort encoded as JS error")
+	}
+	if exp := map[string]any{"message": abortCause.Error()}; !reflect.DeepEqual(exp, abort.CancelReason) {
+		t.Fatalf("expected cancel reason %v, got %v", exp, abort.CancelReason)
+	}
+	if abort.RequestID != nil {
+		t.Fatalf("abort must not have i field, got %+v", abort)
+	}
+
+	// The channel context must be cancelled with the abort cause.
+	select {
+	case <-anon.Context().Done():
+		if cause := context.Cause(anon.Context()); cause == nil || cause.Error() != abortCause.Error() {
+			t.Fatalf("expected cause %q, got %v", abortCause, cause)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("anon channel context was not cancelled")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
+// TestOutboundRequestConnectionCloseBeforeCtxCancelIsHarmless verifies that
+// when the connection closes before the request context is cancelled, the
+// subsequent cancellation does not send a spurious abort message.
+func TestOutboundRequestConnectionCloseBeforeCtxCancelIsHarmless(t *testing.T) {
+	client := NewClient(nil)
+	conn := newMockConn()
+	client.Bind(conn)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	result := make(chan *AnonymousChannel, 1)
+	go func() {
+		resp, err := client.Request(ctx, "stream")
+		if err != nil {
+			return
+		}
+		result <- resp.(*AnonymousChannel)
+	}()
+
+	req := conn.waitWritten(t, time.Second)
+	conn.send(Message{RequestID: req.RequestID, AnonymousChannel: 1})
+
+	var anon *AnonymousChannel
+	select {
+	case anon = <-result:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for anonymous channel")
+	}
+
+	// Close the connection before cancelling the context.
+	_ = client.Close(StatusNormalClosure, "done")
+
+	// Now cancel the request context.
+	cancel(errors.New("too late"))
+
+	// The channel context must already be cancelled (due to connection close).
+	select {
+	case <-anon.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("anon channel context was not cancelled after connection close")
+	}
+
+	// No further messages should be written to the (already closed) connection.
+	select {
+	case msg := <-conn.writeCh:
+		// The Close() call itself sends a close frame — drain any legitimate
+		// close-related writes but fail on abort messages.
+		if msg.CancelReason != nil {
+			t.Fatalf("unexpected abort message after connection close: %+v", msg)
+		}
+	case <-time.After(50 * time.Millisecond):
+	}
 }

--- a/anon_channel_test.go
+++ b/anon_channel_test.go
@@ -135,6 +135,64 @@ func TestHandlerReturnsNilDoesNotSendCreation(t *testing.T) {
 	conn.Close(StatusNormalClosure, "done")
 }
 
+// TestHandlerCreatesAnonChannelButReturnsNil verifies that when a handler
+// obtains an anonymous channel via Channel(ctx) and registers event handlers on
+// it, but then returns nil instead of the channel, the anonymous channel and
+// all of its registered event handlers are properly cleaned up.
+func TestHandlerCreatesAnonChannelButReturnsNil(t *testing.T) {
+	server := NewServer()
+	conn := newMockConn()
+
+	var capturedClient *Client
+	server.On("open", func(c *Client) {
+		capturedClient = c
+	})
+
+	var capturedCh *AnonymousChannel
+	server.On("noChannel", func(ctx context.Context) (*AnonymousChannel, error) {
+		capturedCh = Channel(ctx)
+		// Register an event handler on the anonymous channel
+		capturedCh.On("data", func(v string) error { return nil })
+		// Deliberately not returning capturedCh
+		return nil, nil
+	})
+
+	if err := server.Accept(conn); err != nil {
+		t.Fatal(err)
+	}
+
+	reqID := 1
+	conn.send(Message{
+		RequestID: &reqID,
+		Arguments: []json.RawMessage{[]byte(`"noChannel"`)},
+	})
+
+	// The response is sent only after cleanup, so receiving it confirms cleanup
+	// has already happened.
+	resp := conn.waitWritten(t, time.Second)
+	if resp.AnonymousChannel != 0 {
+		t.Fatalf("expected no creation response (h field), got %+v", resp)
+	}
+
+	// The anonymous channel's context must be cancelled.
+	select {
+	case <-capturedCh.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("anonymous channel context was not cancelled after handler returned nil")
+	}
+
+	// The registered 'data' event handler must have been removed.
+	capturedClient.handlersMu.Lock()
+	key := handlerName{AnonymousChannel: reqID, Event: "data"}
+	_, found := capturedClient.handlers[key]
+	capturedClient.handlersMu.Unlock()
+	if found {
+		t.Fatal("expected 'data' handler to be cleaned up when handler returned nil")
+	}
+
+	conn.Close(StatusNormalClosure, "done")
+}
+
 // ── Routing events/requests to anonymous channel handlers ────────────────────
 
 // TestAnonChannelEventRouted verifies that inbound {h, a} messages are routed

--- a/channel.go
+++ b/channel.go
@@ -131,7 +131,7 @@ func (c *ClientChannel) Close() error {
 	}
 	c.client = nil
 	cl.handlersMu.Lock()
-	closeHandlersForChannel(c.name, cl.handlers, cl.handlersOnce)
+	closeHandlersForChannel(c.name, false, cl.handlers, cl.handlersOnce)
 	cl.handlersMu.Unlock()
 	return nil
 }
@@ -166,7 +166,7 @@ func (c ClientChannel) Emit(ctx context.Context, arguments ...any) error {
 			"cannot emit reserved event '%s' on main channel", eventName,
 		)
 	}
-	return c.client.sendEvent(ctx, c.name, arguments...)
+	return c.client.sendEvent(ctx, c.name, false, arguments...)
 }
 
 // Request sends a request to the client and returns the response. The passed
@@ -187,7 +187,7 @@ func (c ClientChannel) Request(
 			"cannot emit reserved event '%s' on main channel", eventName,
 		)
 	}
-	return c.client.sendRequest(ctx, c.name, arguments...)
+	return c.client.sendRequest(ctx, c.name, false, arguments...)
 }
 
 // Name returns the name of the channel
@@ -255,7 +255,7 @@ func (c *ServerChannel) Close() error {
 	}
 	c.server = nil
 	s.handlersMu.Lock()
-	closeHandlersForChannel(c.name, s.handlers, s.handlersOnce)
+	closeHandlersForChannel(c.name, false, s.handlers, s.handlersOnce)
 	s.handlersMu.Unlock()
 	return nil
 }
@@ -290,7 +290,7 @@ func (c ServerChannel) Emit(
 	defer c.server.clientsMu.Unlock()
 
 	for client := range c.server.clients {
-		err := client.sendEvent(ctx, c.name, arguments...)
+		err := client.sendEvent(ctx, c.name, false, arguments...)
 		if err != nil {
 			errs = append(errs, ClientError{
 				Client: client,

--- a/channel.go
+++ b/channel.go
@@ -174,7 +174,7 @@ func (ch *ClientChannel) Close() error {
 	}
 	ch.client = nil
 	c.handlersMu.Lock()
-	closeHandlersForChannel(ch.name, false, c.handlers, c.handlersOnce)
+	closeHandlersForChannel(ch.name, 0, c.handlers, c.handlersOnce)
 	c.handlersMu.Unlock()
 	return nil
 }
@@ -239,7 +239,7 @@ func (c *ServerChannel) Close() error {
 	}
 	c.server = nil
 	s.handlersMu.Lock()
-	closeHandlersForChannel(c.name, false, s.handlers, s.handlersOnce)
+	closeHandlersForChannel(c.name, 0, s.handlers, s.handlersOnce)
 	s.handlersMu.Unlock()
 	return nil
 }

--- a/channel.go
+++ b/channel.go
@@ -82,58 +82,25 @@ type ClientChannel struct {
 //
 // If On is called multiple times for the same event name, the last handler
 // will be used. If handler is nil, the event handler is removed.
-func (c ClientChannel) On(eventName string, handler any) ClientChannel {
-	if c.client == nil {
-		return c // channel closed; do nothing
+func (ch ClientChannel) On(eventName string, handler any) ClientChannel {
+	c := ch.client
+	if c != nil {
+		key := handlerName{Channel: ch.name, Event: eventName}
+		registerClientHandler(c, key, handler, false)
 	}
-	if err := checkHandler(c.name, eventName, handler); err != nil {
-		panic(err)
-	}
-	key := handlerName{Channel: c.name, Event: eventName}
-	c.client.handlersMu.Lock()
-	if handler == nil {
-		delete(c.client.handlers, key)
-	} else {
-		c.client.handlers[key] = handler
-	}
-	c.client.handlersMu.Unlock()
-	return c
+	return ch
 }
 
 // Once adds a one-time event handler for the specified event to the channel.
 // See ClientChannel.On for more information about how event handlers are
 // called.
-func (c ClientChannel) Once(eventName string, handler any) ClientChannel {
-	if c.client == nil {
-		return c // channel closed; do nothing
+func (ch ClientChannel) Once(eventName string, handler any) ClientChannel {
+	c := ch.client
+	if c != nil {
+		key := handlerName{Channel: ch.name, Event: eventName}
+		registerClientHandler(c, key, handler, true)
 	}
-	if err := checkHandler(c.name, eventName, handler); err != nil {
-		panic(err)
-	}
-	key := handlerName{Channel: c.name, Event: eventName}
-	c.client.handlersMu.Lock()
-	if handler == nil {
-		delete(c.client.handlersOnce, key)
-	} else {
-		c.client.handlersOnce[key] = handler
-	}
-	c.client.handlersMu.Unlock()
-	return c
-}
-
-// Close removes all event handlers for this channel.
-//
-// Close returns nil.
-func (c *ClientChannel) Close() error {
-	cl := c.client
-	if cl == nil {
-		return nil // channel closed already
-	}
-	c.client = nil
-	cl.handlersMu.Lock()
-	closeHandlersForChannel(c.name, false, cl.handlers, cl.handlersOnce)
-	cl.handlersMu.Unlock()
-	return nil
+	return ch
 }
 
 // checkEventName ensures the event name is valid and returns it as a string.
@@ -149,50 +116,67 @@ func checkEventName(arguments []any) (string, error) {
 }
 
 // Emit sends an event to the client on the specified channel. The passed
-// context can be used to cancel writing the message to the client. The second
-// argument is the event name that tells the remote end which event handler to
-// call. Returns an error if there was an error sending the message to the
+// context can be used to cancel writing the message to the client. The first
+// argument must be the event name that tells the remote end which event handler
+// to call. Returns an error if there was an error sending the message to the
 // client.
-func (c ClientChannel) Emit(ctx context.Context, arguments ...any) error {
-	if c.client == nil {
-		return ChannelClosedError{Channel: c.name}
+func (ch ClientChannel) Emit(ctx context.Context, arguments ...any) error {
+	c := ch.client
+	if c == nil {
+		return ChannelClosedError{Channel: ch.name}
 	}
 	eventName, err := checkEventName(arguments)
 	if err != nil {
 		return err
 	}
-	if c.name == "" && IsReservedEvent(eventName) {
+	if ch.name == "" && IsReservedEvent(eventName) {
 		return fmt.Errorf(
 			"cannot emit reserved event '%s' on main channel", eventName,
 		)
 	}
-	return c.client.sendEvent(ctx, c.name, false, arguments...)
+	return c.sendEvent(ctx, ch.name, false, arguments...)
 }
 
 // Request sends a request to the client and returns the response. The passed
-// context can be used to cancel the request. The second argument is the event
+// context can be used to cancel the request. The first argument is the event
 // name that tells the remote end which request handler to call.
-func (c ClientChannel) Request(
+func (ch ClientChannel) Request(
 	ctx context.Context, arguments ...any,
 ) (response any, err error) {
-	if c.client == nil {
-		return nil, ChannelClosedError{Channel: c.name}
+	c := ch.client
+	if c == nil {
+		return nil, ChannelClosedError{Channel: ch.name}
 	}
 	eventName, err := checkEventName(arguments)
 	if err != nil {
 		return nil, err
 	}
-	if c.name == "" && IsReservedEvent(eventName) {
+	if ch.name == "" && IsReservedEvent(eventName) {
 		return nil, fmt.Errorf(
 			"cannot emit reserved event '%s' on main channel", eventName,
 		)
 	}
-	return c.client.sendRequest(ctx, c.name, false, arguments...)
+	return c.sendRequest(ctx, ch.name, false, arguments...)
 }
 
 // Name returns the name of the channel
-func (c ClientChannel) Name() string {
-	return c.name
+func (ch ClientChannel) Name() string {
+	return ch.name
+}
+
+// Close removes all event handlers for this channel.
+//
+// Close returns nil.
+func (ch *ClientChannel) Close() error {
+	c := ch.client
+	if c == nil {
+		return nil // already closed
+	}
+	ch.client = nil
+	c.handlersMu.Lock()
+	closeHandlersForChannel(ch.name, false, c.handlers, c.handlersOnce)
+	c.handlersMu.Unlock()
+	return nil
 }
 
 // ServerChannel is a channel on which events can be sent and received. Events

--- a/channel.go
+++ b/channel.go
@@ -134,7 +134,7 @@ func (ch ClientChannel) Emit(ctx context.Context, arguments ...any) error {
 			"cannot emit reserved event '%s' on main channel", eventName,
 		)
 	}
-	return c.sendEvent(ctx, ch.name, false, arguments...)
+	return c.sendEvent(ctx, ch.name, 0, arguments...)
 }
 
 // Request sends a request to the client and returns the response. The passed
@@ -156,7 +156,7 @@ func (ch ClientChannel) Request(
 			"cannot emit reserved event '%s' on main channel", eventName,
 		)
 	}
-	return c.sendRequest(ctx, ch.name, false, arguments...)
+	return c.sendRequest(ctx, ch.name, 0, arguments...)
 }
 
 // Name returns the name of the channel
@@ -274,7 +274,7 @@ func (c ServerChannel) Emit(
 	defer c.server.clientsMu.Unlock()
 
 	for client := range c.server.clients {
-		err := client.sendEvent(ctx, c.name, false, arguments...)
+		err := client.sendEvent(ctx, c.name, 0, arguments...)
 		if err != nil {
 			errs = append(errs, ClientError{
 				Client: client,

--- a/client.go
+++ b/client.go
@@ -130,13 +130,17 @@ func (c *Client) Bind(conn Conn) {
 	prevAnonChans := c.anonChans
 	c.anonChans = make(map[string]*AnonymousChannel)
 	c.connReqMu.Unlock()
-	for _, ch := range prevAnonChans {
-		ch.closeWithCause(errRebound)
-	}
 
+	// Close previous connection / anonymous channels
 	if oldConn != nil {
 		_ = oldConn.Close(StatusGoingAway, errRebound.Error())
 	}
+	c.handlersMu.Lock()
+	for _, ch := range prevAnonChans {
+		closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
+		ch.closeDetached(errRebound)
+	}
+	c.handlersMu.Unlock()
 
 	// Fire "open" handlers synchronously before launching readMessages so that
 	// any handlers registered inside the "open" callback are in place before
@@ -194,9 +198,12 @@ func (c *Client) close(
 	c.connReqMu.Unlock()
 
 	// Close all anonymous channels (snapshot-clear-then-close to avoid deadlock).
+	c.handlersMu.Lock()
 	for _, ch := range anonChans {
-		ch.closeWithCause(errClosed)
+		closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
+		ch.closeDetached(errClosed)
 	}
+	c.handlersMu.Unlock()
 
 	// Emit "close" events and close the connection
 	c.emitClose(status, reason, userClosed)

--- a/client.go
+++ b/client.go
@@ -612,17 +612,17 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// Anonymous channel creation response: {i, h} (no Arguments; CancelReason
 	// was handled above so it is nil here)
 	if msg.AnonymousChannel != 0 {
-		chanID := *msg.RequestID
 		c.connReqMu.Lock()
 		respCh, ok := c.requestResponseCh[*msg.RequestID]
 		if ok {
 			delete(c.requestResponseCh, *msg.RequestID)
 		}
+		chanID := *msg.RequestID
 		anon := newAnonymousChannel(ctx, chanID, c)
 		c.anonChans[chanID] = anon
 		c.connReqMu.Unlock()
 		if respCh == nil {
-			return nil
+			return nil // ignore message with invalid request ID
 		}
 		respCh <- messageResponse{anon, nil}
 		close(respCh)
@@ -761,6 +761,8 @@ func (c *Client) handleEvent(
 		handlerCtx = context.WithValue(
 			handlerCtx, anonChannelKey{}, func() *AnonymousChannel {
 				if anonChan == nil {
+					// Anonymous channel uses connection context, not request
+					// context
 					anonChan = newAnonymousChannel(ctx, *msg.RequestID, c)
 				}
 				return anonChan
@@ -768,23 +770,25 @@ func (c *Client) handleEvent(
 		)
 	}
 
+	// Launch event handler in its own goroutine
 	go func() {
 		defer close(msg.processed)
 		result, err := callHandler(handlerCtx, handler, msg.HandlerArguments())
+		// We are done running the handler, so cancel the handler context
 		if cancel != nil {
 			cancel(context.Canceled)
 		}
 
-		// For event messages (not requests), clean up any factory channel that
-		// was created but not returned, then return. inboundCancels is only
-		// populated for requests, so there is nothing to remove here.
+		// Silently ignore the response if it's not a request
 		if msg.RequestID == nil {
+			// Clean up the anonymous channel if one was created
 			if anonChan != nil {
 				anonChan.closeWithCause(context.Canceled)
 			}
 			return
 		}
 
+		// Clean up inbound cancellation
 		c.inboundCancelsMu.Lock()
 		delete(c.inboundCancels, *msg.RequestID)
 		c.inboundCancelsMu.Unlock()
@@ -796,27 +800,28 @@ func (c *Client) handleEvent(
 		// different channel with the same ID.
 		var sendErr error
 		if err != nil {
-			// Handler returned an error; clean up any factory channel created
+			// Clean up the anonymous channel if one was created
 			if anonChan != nil {
 				anonChan.closeWithCause(context.Canceled)
 			}
+			// Send error response
 			sendErr = c.sendReject(ctx, msg.RequestID, err)
-		} else if result == anonChan && anonChan != nil {
-			// Handler returned the factory anonymous channel; register and
-			// notify
+		} else if anonChan != nil && result == anonChan {
+			// Handler returned the anonymous channel; register and notify
 			c.connReqMu.Lock()
 			c.anonChans[*msg.RequestID] = anonChan
 			c.connReqMu.Unlock()
 			sendErr = c.sendResolveAnon(ctx, msg.RequestID)
 		} else {
-			// Handler returned a regular value (or nil / a different anon
-			// channel); close the factory channel if one was created
+			// Clean up the anonymous channel if one was created
 			if anonChan != nil {
 				anonChan.closeWithCause(context.Canceled)
 			}
+			// Send data response
 			sendErr = c.sendResolve(ctx, msg.RequestID, result)
 		}
 		if sendErr != nil {
+			// Emit error and close client
 			sendErr = fmt.Errorf("responding to request: %w", sendErr)
 			c.emitError(sendErr)
 			if c.server != nil {

--- a/client.go
+++ b/client.go
@@ -136,8 +136,9 @@ func (c *Client) Bind(conn Conn) {
 	}
 	c.handlersMu.Lock()
 	for _, ch := range prevAnonChans {
+		ch.client = nil
 		closeHandlersForChannel("", ch.id, c.handlers, c.handlersOnce)
-		ch.closeDetached(errRebound)
+		ch.ctxCancel(errRebound)
 	}
 	c.handlersMu.Unlock()
 
@@ -199,8 +200,9 @@ func (c *Client) close(
 	// Close all anonymous channels (snapshot-clear-then-close to avoid deadlock).
 	c.handlersMu.Lock()
 	for _, ch := range anonChans {
+		ch.client = nil
 		closeHandlersForChannel("", ch.id, c.handlers, c.handlersOnce)
-		ch.closeDetached(errClosed)
+		ch.ctxCancel(errClosed)
 	}
 	c.handlersMu.Unlock()
 

--- a/client.go
+++ b/client.go
@@ -137,7 +137,7 @@ func (c *Client) Bind(conn Conn) {
 	}
 	c.handlersMu.Lock()
 	for _, ch := range prevAnonChans {
-		closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
+		closeHandlersForChannel("", ch.id, c.handlers, c.handlersOnce)
 		ch.closeDetached(errRebound)
 	}
 	c.handlersMu.Unlock()
@@ -200,7 +200,7 @@ func (c *Client) close(
 	// Close all anonymous channels (snapshot-clear-then-close to avoid deadlock).
 	c.handlersMu.Lock()
 	for _, ch := range anonChans {
-		closeHandlersForChannel(ch.name, true, c.handlers, c.handlersOnce)
+		closeHandlersForChannel("", ch.id, c.handlers, c.handlersOnce)
 		ch.closeDetached(errClosed)
 	}
 	c.handlersMu.Unlock()
@@ -664,7 +664,12 @@ func (c *Client) handleInboundMessage(
 	}
 
 	// Look up handler (client-specific first)
-	handlerID := handlerName{Channel: chanID, Anonymous: anonID != 0, Event: eventName}
+	var handlerID handlerName
+	if anonID != 0 {
+		handlerID = handlerName{AnonymousChannel: anonID, Event: eventName}
+	} else {
+		handlerID = handlerName{Channel: chanID, Event: eventName}
+	}
 	c.handlersMu.Lock()
 	handler, ok := c.handlersOnce[handlerID]
 	if ok {

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 )
 
@@ -27,6 +28,8 @@ type Client struct {
 	handlersMu        sync.Mutex
 	handlers          map[handlerName]any
 	handlersOnce      map[handlerName]any
+	anonChansMu       sync.Mutex
+	anonChans         map[string]*AnonymousChannel
 	dataMu            sync.Mutex
 	data              map[string]any
 	server            *Server // server associated with the Client
@@ -59,6 +62,7 @@ func NewClient(conn Conn) *Client {
 		inboundCancels:    make(map[int]func(error)),
 		handlers:          make(map[handlerName]any),
 		handlersOnce:      make(map[handlerName]any),
+		anonChans:         make(map[string]*AnonymousChannel),
 		data:              make(map[string]any),
 		// server is set only by Server.Accept
 	}
@@ -118,13 +122,19 @@ func (c *Client) Bind(conn Conn) {
 	// Create a context that is cancelled when the connection is closed.
 	// I know it is generally frowned upon to store the Context in a struct, but
 	// we are using it as a signal to cancel readMessages and for request
-	// cancellation. I also feel like this approach is slightly better than
-	// using a channel; previously a goroutine per client was created simply to
-	// read from a close channel and cancel the readMessages Context. It feels
-	// a bit wasteful.
+	// cancellation.
 	c.ctx, c.ctxCancel = context.WithCancelCause(context.Background())
-	c.ctx = context.WithValue(c.ctx, ClientKey, c)
+	c.ctx = context.WithValue(c.ctx, clientKey{}, c)
 	c.connReqMu.Unlock()
+
+	// Close all anonymous channels from the previous connection.
+	c.anonChansMu.Lock()
+	prevAnonChans := c.anonChans
+	c.anonChans = make(map[string]*AnonymousChannel)
+	c.anonChansMu.Unlock()
+	for _, ch := range prevAnonChans {
+		ch.closeWithCause(errRebound)
+	}
 
 	if oldConn != nil {
 		_ = oldConn.Close(StatusGoingAway, errRebound.Error())
@@ -182,6 +192,16 @@ func (c *Client) close(
 	}
 	clear(c.requestResponseCh)
 	c.connReqMu.Unlock()
+
+	// Close all anonymous channels (snapshot-clear-then-close to avoid deadlock).
+	c.anonChansMu.Lock()
+	anonChans := c.anonChans
+	c.anonChans = make(map[string]*AnonymousChannel)
+	c.anonChansMu.Unlock()
+	for _, ch := range anonChans {
+		ch.closeWithCause(fmt.Errorf("connection closed"))
+	}
+
 	// Emit "close" events and close the connection
 	c.emitClose(status, reason, userClosed)
 	if c.server != nil {
@@ -284,7 +304,7 @@ func (c *Client) sendResolve(ctx context.Context, requestID *int, data any) erro
 }
 
 // sendEvent sends an event to the client
-func (c *Client) sendEvent(ctx context.Context, channel string, arguments ...any) error {
+func (c *Client) sendEvent(ctx context.Context, channel string, anonymous bool, arguments ...any) error {
 	c.connReqMu.Lock()
 	conn := c.conn
 	c.connReqMu.Unlock()
@@ -301,15 +321,18 @@ func (c *Client) sendEvent(ctx context.Context, channel string, arguments ...any
 		jsonArgs[i] = buf
 	}
 	// Send event to client
-	return conn.WriteMessage(ctx, &Message{
-		Channel:   channel,
-		Arguments: jsonArgs,
-	})
+	msg := &Message{Arguments: jsonArgs}
+	if anonymous {
+		msg.AnonymousChannel = anonChannelH(channel)
+	} else {
+		msg.Channel = channel
+	}
+	return conn.WriteMessage(ctx, msg)
 }
 
 // sendRequest sends a request to the client and returns the response
 func (c *Client) sendRequest(
-	ctx context.Context, channel string, arguments ...any,
+	ctx context.Context, channel string, anonymous bool, arguments ...any,
 ) (any, error) {
 	c.connReqMu.Lock()
 	conn := c.conn
@@ -343,11 +366,13 @@ func (c *Client) sendRequest(
 	}
 
 	// Send request to client
-	err := conn.WriteMessage(ctx, &Message{
-		Channel:   channel,
-		Arguments: jsonArgs,
-		RequestID: &requestID,
-	})
+	msg := &Message{Arguments: jsonArgs, RequestID: &requestID}
+	if anonymous {
+		msg.AnonymousChannel = anonChannelH(channel)
+	} else {
+		msg.Channel = channel
+	}
+	err := conn.WriteMessage(ctx, msg)
 	if err != nil {
 		c.connReqMu.Lock()
 		delete(c.requestResponseCh, requestID)
@@ -369,6 +394,40 @@ func (c *Client) sendRequest(
 		_ = c.sendCancel(ctxClient, &requestID, cancelCause)
 		return nil, fmt.Errorf("awaiting response: %w", cancelCause)
 	}
+}
+
+// sendAnonCancel sends an anonymous channel abort message to the client.
+func (c *Client) sendAnonCancel(ctx context.Context, chanID string, reason error) error {
+	if reason == nil {
+		reason = context.Canceled
+	}
+	c.connReqMu.Lock()
+	conn := c.conn
+	c.connReqMu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	return conn.WriteMessage(ctx, &Message{
+		AnonymousChannel: anonChannelH(chanID),
+		ResponseJSError:  true,
+		CancelReason: map[string]any{
+			"message": reason.Error(),
+		},
+	})
+}
+
+// sendAnonCreation sends an anonymous channel creation response to the client.
+func (c *Client) sendAnonCreation(ctx context.Context, requestID *int, chanID string) error {
+	c.connReqMu.Lock()
+	conn := c.conn
+	c.connReqMu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	return conn.WriteMessage(ctx, &Message{
+		RequestID:        requestID,
+		AnonymousChannel: anonChannelH(chanID),
+	})
 }
 
 // readMessages reads messages from the client connection and handles them.
@@ -497,119 +556,52 @@ func (c *Client) emitClose(s StatusCode, reason string, userClosed bool) bool {
 // handleMessage processes an inbound message for this client. Returns an error
 // if there was an error sending the response to the client.
 func (c *Client) handleMessage(ctx context.Context, msg Message) error {
-	// We may create a request-specific cancellable context later
-	var cancel context.CancelCauseFunc
 	// Get message event name if any
 	eventName := msg.EventName()
 	if eventName != "" {
-		// Process inbound event/request
-		handlerID := handlerName{Channel: msg.Channel, Event: eventName}
-
-		// Get client-specific handler
-		c.handlersMu.Lock()
-		handler, ok := c.handlersOnce[handlerID]
-		if ok {
-			delete(c.handlersOnce, handlerID)
-		} else {
-			handler = c.handlers[handlerID]
+		if msg.AnonymousChannel != "" {
+			return c.handleAnonChannelMessage(ctx, msg, eventName)
 		}
-		c.handlersMu.Unlock()
-
-		// Get server's handler Context function
-		var handlerCtxFunc HandlerContextFunc
-		if c.server != nil {
-			c.server.handlersMu.Lock()
-			handlerCtxFunc = c.server.handlerCtxFunc
-			// Get server handler if no client handler exists
-			if handler == nil {
-				handler, ok = c.server.handlersOnce[handlerID]
-				if ok {
-					delete(c.server.handlersOnce, handlerID)
-				} else {
-					handler = c.server.handlers[handlerID]
-				}
-			}
-			c.server.handlersMu.Unlock()
-		}
-
-		// Handle missing handler
-		if handler == nil {
-			defer close(msg.processed)
-			err := fmt.Errorf(
-				"no event listener for '%s' on channel '%s'",
-				eventName, msg.Channel,
-			)
-			if msg.Channel == "" {
-				err = fmt.Errorf("no event listener for '%s'", eventName)
-			}
-			// Send error response if it's a request
-			if msg.RequestID != nil {
-				return c.sendReject(ctx, msg.RequestID, err)
-			}
-			// Otherwise, ignore this message
-			return nil
-		}
-
-		// Wrap context for handler execution
-		handlerCtx := ctx
-		if handlerCtxFunc != nil {
-			handlerCtx = handlerCtxFunc(ctx, msg.Channel, eventName)
-		}
-		// For inbound requests, create a request-specific cancellable context
-		// to allow a protocol-level cancellation message to cancel the handler.
-		if msg.RequestID != nil {
-			handlerCtx, cancel = context.WithCancelCause(handlerCtx)
-			// Save the CancelCauseFunc for the request
-			c.inboundCancelsMu.Lock()
-			c.inboundCancels[*msg.RequestID] = cancel
-			c.inboundCancelsMu.Unlock()
-		}
-
-		// Call handler with arguments
-		go func() {
-			defer close(msg.processed)
-			result, err := callHandler(
-				handlerCtx, handler, msg.HandlerArguments(),
-			)
-			// We are done running the handler, so cancel the handler context
-			if cancel != nil {
-				cancel(context.Canceled)
-			}
-
-			if msg.RequestID == nil {
-				// Silently ignore the response if it's not a request
-				return
-			}
-
-			// Clean up inbound cancellation
-			c.inboundCancelsMu.Lock()
-			delete(c.inboundCancels, *msg.RequestID)
-			c.inboundCancelsMu.Unlock()
-
-			if err != nil {
-				// Send error response
-				err = c.sendReject(ctx, msg.RequestID, err)
-			} else {
-				// Send data response
-				err = c.sendResolve(ctx, msg.RequestID, result)
-			}
-			if err != nil {
-				// Emit error and close client
-				err = fmt.Errorf("responding to request: %w", err)
-				c.emitError(err)
-				if c.server != nil {
-					c.server.emitError(c, err)
-				}
-				c.close(StatusInternalError, err.Error(), false, false)
-			}
-		}()
-		return nil
+		return c.handleRegularMessage(ctx, msg, eventName)
 	}
 	defer close(msg.processed)
 
+	// Inbound anonymous channel abort: {h, x} (no RequestID needed)
+	if msg.AnonymousChannel != "" && msg.CancelReason != nil {
+		chanID := string(msg.AnonymousChannel)
+		c.anonChansMu.Lock()
+		ch, ok := c.anonChans[chanID]
+		c.anonChansMu.Unlock()
+		if ok {
+			ch.closeWithCause(msg.parseCancelReason())
+		}
+		return nil
+	}
+
 	// Try processing response to prior request
 	if msg.RequestID == nil {
-		return nil // ignore message with invalid request ID
+		return nil // ignore message with no request ID
+	}
+
+	// Anonymous channel creation response: {i, h} (no CancelReason, no Arguments)
+	if msg.AnonymousChannel != "" && msg.CancelReason == nil {
+		chanID := strconv.Itoa(*msg.RequestID)
+		c.connReqMu.Lock()
+		respCh, ok := c.requestResponseCh[*msg.RequestID]
+		if ok {
+			delete(c.requestResponseCh, *msg.RequestID)
+		}
+		c.connReqMu.Unlock()
+		if respCh == nil {
+			return nil
+		}
+		anon := newAnonymousChannel(chanID, c)
+		c.anonChansMu.Lock()
+		c.anonChans[chanID] = anon
+		c.anonChansMu.Unlock()
+		respCh <- messageResponse{anon, nil}
+		close(respCh)
+		return nil
 	}
 
 	// Handle request cancellation message (ws-wrapper v4)
@@ -642,5 +634,281 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	respCh <- messageResponse{res, err}
 	close(respCh)
 
+	return nil
+}
+
+// handleRegularMessage handles an inbound event or request on a named or main
+// channel (msg.AnonymousChannel == "").
+func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventName string) error {
+	// We may create a request-specific cancellable context later
+	var cancel context.CancelCauseFunc
+
+	// Process inbound event/request
+	handlerID := handlerName{Channel: msg.Channel, Anonymous: false, Event: eventName}
+
+	// Get client-specific handler
+	c.handlersMu.Lock()
+	handler, ok := c.handlersOnce[handlerID]
+	if ok {
+		delete(c.handlersOnce, handlerID)
+	} else {
+		handler = c.handlers[handlerID]
+	}
+	c.handlersMu.Unlock()
+
+	// Get server's handler context function
+	var handlerCtxFunc HandlerContextFunc
+	if c.server != nil {
+		c.server.handlersMu.Lock()
+		handlerCtxFunc = c.server.handlerCtxFunc
+		// Get server handler if no client handler exists
+		if handler == nil {
+			handler, ok = c.server.handlersOnce[handlerID]
+			if ok {
+				delete(c.server.handlersOnce, handlerID)
+			} else {
+				handler = c.server.handlers[handlerID]
+			}
+		}
+		c.server.handlersMu.Unlock()
+	}
+
+	// Handle missing handler
+	if handler == nil {
+		defer close(msg.processed)
+		err := fmt.Errorf(
+			"no event listener for '%s' on channel '%s'",
+			eventName, msg.Channel,
+		)
+		if msg.Channel == "" {
+			err = fmt.Errorf("no event listener for '%s'", eventName)
+		}
+		// Send error response if it's a request
+		if msg.RequestID != nil {
+			return c.sendReject(ctx, msg.RequestID, err)
+		}
+		// Otherwise, ignore this message
+		return nil
+	}
+
+	// Wrap context for handler execution
+	handlerCtx := ctx
+	if handlerCtxFunc != nil {
+		handlerCtx = handlerCtxFunc(ctx, msg.Channel, eventName)
+	}
+	// For inbound requests, create a request-specific cancellable context and
+	// inject the anonymous channel factory.
+	var factoryChan *AnonymousChannel
+	if msg.RequestID != nil {
+		handlerCtx, cancel = context.WithCancelCause(handlerCtx)
+		// Save the CancelCauseFunc for the request
+		c.inboundCancelsMu.Lock()
+		c.inboundCancels[*msg.RequestID] = cancel
+		c.inboundCancelsMu.Unlock()
+
+		// Inject anonymous channel factory so the handler can call Channel(ctx)
+		chanID := strconv.Itoa(*msg.RequestID)
+		factory := func() *AnonymousChannel {
+			if factoryChan == nil {
+				factoryChan = newAnonymousChannel(chanID, c)
+			}
+			return factoryChan
+		}
+		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, factory)
+	}
+
+	// Call handler with arguments
+	go func() {
+		defer close(msg.processed)
+		result, err := callHandler(
+			handlerCtx, handler, msg.HandlerArguments(),
+		)
+		// We are done running the handler, so cancel the handler context
+		if cancel != nil {
+			cancel(context.Canceled)
+		}
+
+		if msg.RequestID == nil {
+			// Silently ignore the response if it's not a request
+			if factoryChan != nil {
+				factoryChan.ctxCancel(context.Canceled) // cleanup unused factory
+			}
+			return
+		}
+
+		// Clean up inbound cancellation
+		c.inboundCancelsMu.Lock()
+		delete(c.inboundCancels, *msg.RequestID)
+		c.inboundCancelsMu.Unlock()
+
+		chanID := strconv.Itoa(*msg.RequestID)
+
+		// Check if handler returned the factory anonymous channel
+		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == factoryChan {
+			c.anonChansMu.Lock()
+			c.anonChans[chanID] = anon
+			c.anonChansMu.Unlock()
+			sendErr := c.sendAnonCreation(ctx, msg.RequestID, chanID)
+			if sendErr != nil {
+				sendErr = fmt.Errorf("responding to request: %w", sendErr)
+				c.emitError(sendErr)
+				if c.server != nil {
+					c.server.emitError(c, sendErr)
+				}
+				c.close(StatusInternalError, sendErr.Error(), false, false)
+			}
+			return
+		}
+		// Clean up unused factory channel if one was created
+		if factoryChan != nil {
+			factoryChan.ctxCancel(context.Canceled)
+		}
+
+		if err != nil {
+			// Send error response
+			err = c.sendReject(ctx, msg.RequestID, err)
+		} else {
+			// Send data response
+			err = c.sendResolve(ctx, msg.RequestID, result)
+		}
+		if err != nil {
+			// Emit error and close client
+			err = fmt.Errorf("responding to request: %w", err)
+			c.emitError(err)
+			if c.server != nil {
+				c.server.emitError(c, err)
+			}
+			c.close(StatusInternalError, err.Error(), false, false)
+		}
+	}()
+	return nil
+}
+
+// handleAnonChannelMessage handles an inbound event or request on an anonymous
+// channel (msg.AnonymousChannel != "").
+func (c *Client) handleAnonChannelMessage(ctx context.Context, msg Message, eventName string) error {
+	var anonCancel context.CancelCauseFunc
+	chanID := string(msg.AnonymousChannel)
+
+	// Lookup the anonymous channel
+	c.anonChansMu.Lock()
+	_, ok := c.anonChans[chanID]
+	c.anonChansMu.Unlock()
+	if !ok {
+		// Unknown anonymous channel: notify remote and reject any sub-request
+		defer close(msg.processed)
+		err := fmt.Errorf("anonymous channel '%s' not found", chanID)
+		_ = c.sendAnonCancel(ctx, chanID, err)
+		if msg.RequestID != nil {
+			return c.sendReject(ctx, msg.RequestID, err)
+		}
+		return nil
+	}
+
+	// Route to anonymous channel's handlers (client-side only; no server fallback)
+	handlerID := handlerName{Channel: chanID, Anonymous: true, Event: eventName}
+	c.handlersMu.Lock()
+	handler, ok := c.handlersOnce[handlerID]
+	if ok {
+		delete(c.handlersOnce, handlerID)
+	} else {
+		handler = c.handlers[handlerID]
+	}
+	c.handlersMu.Unlock()
+
+	// Handle missing handler for anonymous channel
+	if handler == nil {
+		defer close(msg.processed)
+		err := fmt.Errorf(
+			"no event listener for '%s' on anonymous channel '%s'",
+			eventName, chanID,
+		)
+		if msg.RequestID != nil {
+			return c.sendReject(ctx, msg.RequestID, err)
+		}
+		return nil
+	}
+
+	// Wrap context for handler execution
+	handlerCtx := ctx
+	if c.server != nil {
+		c.server.handlersMu.Lock()
+		handlerCtxFunc := c.server.handlerCtxFunc
+		c.server.handlersMu.Unlock()
+		if handlerCtxFunc != nil {
+			handlerCtx = handlerCtxFunc(ctx, chanID, eventName)
+		}
+	}
+	// For inbound sub-requests on anonymous channels, create a cancellable
+	// context and inject a nested anonymous channel factory.
+	var factoryChan *AnonymousChannel
+	if msg.RequestID != nil {
+		handlerCtx, anonCancel = context.WithCancelCause(handlerCtx)
+		c.inboundCancelsMu.Lock()
+		c.inboundCancels[*msg.RequestID] = anonCancel
+		c.inboundCancelsMu.Unlock()
+
+		subChanID := strconv.Itoa(*msg.RequestID)
+		factory := func() *AnonymousChannel {
+			if factoryChan == nil {
+				factoryChan = newAnonymousChannel(subChanID, c)
+			}
+			return factoryChan
+		}
+		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, factory)
+	}
+
+	go func() {
+		defer close(msg.processed)
+		result, err := callHandler(handlerCtx, handler, msg.HandlerArguments())
+		if anonCancel != nil {
+			anonCancel(context.Canceled)
+		}
+		if msg.RequestID == nil {
+			if factoryChan != nil {
+				factoryChan.ctxCancel(context.Canceled)
+			}
+			return
+		}
+		c.inboundCancelsMu.Lock()
+		delete(c.inboundCancels, *msg.RequestID)
+		c.inboundCancelsMu.Unlock()
+
+		subChanID := strconv.Itoa(*msg.RequestID)
+
+		// Check if handler returned the factory anonymous channel
+		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == factoryChan {
+			c.anonChansMu.Lock()
+			c.anonChans[subChanID] = anon
+			c.anonChansMu.Unlock()
+			sendErr := c.sendAnonCreation(ctx, msg.RequestID, subChanID)
+			if sendErr != nil {
+				sendErr = fmt.Errorf("responding to request: %w", sendErr)
+				c.emitError(sendErr)
+				if c.server != nil {
+					c.server.emitError(c, sendErr)
+				}
+				c.close(StatusInternalError, sendErr.Error(), false, false)
+			}
+			return
+		}
+		if factoryChan != nil {
+			factoryChan.ctxCancel(context.Canceled)
+		}
+
+		if err != nil {
+			err = c.sendReject(ctx, msg.RequestID, err)
+		} else {
+			err = c.sendResolve(ctx, msg.RequestID, result)
+		}
+		if err != nil {
+			err = fmt.Errorf("responding to request: %w", err)
+			c.emitError(err)
+			if c.server != nil {
+				c.server.emitError(c, err)
+			}
+			c.close(StatusInternalError, err.Error(), false, false)
+		}
+	}()
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ var errClosed = errors.New("connection closed")
 // Client represents a WebSocket client
 type Client struct {
 	ClientChannel                     // the "main" client channel with no name
-	connReqMu         sync.Mutex      // protects Context, Conn, requests, and anonChans
+	connReqMu         sync.Mutex      // protects ctx, Conn, requests, and anonChans
 	ctx               context.Context // cancelled when the connection is closed
 	ctxCancel         func(error)     // called when the connection is closed
 	conn              Conn            // WebSocket connection; set `nil` on close
@@ -94,14 +94,19 @@ func NewClient(conn Conn) *Client {
 // the userClosed parameter to distinguish a user-initiated close from a
 // connection drop — only reconnect when userClosed is false:
 //
-//	client.On("close", func(c *wrapper.Client, status wrapper.StatusCode, reason string, userClosed bool) {
-//	    if userClosed {
-//	        return // don't reconnect when the user explicitly closed
-//	    }
-//	    conn, err := websocket.Dial(ctx, "ws://example.com/ws", nil)
-//	    if err == nil {
-//	        c.Bind(coder.Wrap(conn))
-//	    }
+//	client.On("close", func(
+//		c *wrapper.Client,
+//		status wrapper.StatusCode,
+//		reason string,
+//		userClosed bool,
+//	 ) {
+//		if userClosed {
+//			return // don't reconnect when the user explicitly closed
+//		}
+//		conn, err := websocket.Dial(ctx, "ws://example.com/ws", nil)
+//		if err == nil {
+//			c.Bind(coder.Wrap(conn))
+//		}
 //	})
 func (c *Client) Bind(conn Conn) {
 	c.connReqMu.Lock()
@@ -197,7 +202,7 @@ func (c *Client) close(
 	c.anonChans = make(map[int]*AnonymousChannel)
 	c.connReqMu.Unlock()
 
-	// Close all anonymous channels (snapshot-clear-then-close to avoid deadlock).
+	// Close all anonymous channels
 	c.handlersMu.Lock()
 	for _, ch := range anonChans {
 		ch.client = nil
@@ -237,7 +242,9 @@ func (c *Client) Of(name string) ClientChannel {
 }
 
 // sendReject sends a reject / error response to a request
-func (c *Client) sendReject(ctx context.Context, requestID *int, err error) error {
+func (c *Client) sendReject(
+	ctx context.Context, requestID *int, err error,
+) error {
 	if requestID == nil {
 		return fmt.Errorf("requestID is required")
 	} else if err == nil {
@@ -290,7 +297,9 @@ func (c *Client) sendCancel(
 
 // sendAnonCancel sends an anonymous channel abort message to the client and
 // closes the anonymous channel.
-func (c *Client) sendAnonCancel(ctx context.Context, chanID int, reason error) error {
+func (c *Client) sendAnonCancel(
+	ctx context.Context, chanID int, reason error,
+) error {
 	if reason == nil {
 		reason = context.Canceled
 	}
@@ -317,7 +326,9 @@ func (c *Client) sendAnonCancel(ctx context.Context, chanID int, reason error) e
 }
 
 // sendResolve sends a resolve / data response to a request
-func (c *Client) sendResolve(ctx context.Context, requestID *int, data any) error {
+func (c *Client) sendResolve(
+	ctx context.Context, requestID *int, data any,
+) error {
 	if requestID == nil {
 		return fmt.Errorf("requestID is required")
 	}
@@ -349,7 +360,9 @@ func (c *Client) sendResolveAnon(ctx context.Context, requestID *int) error {
 }
 
 // sendEvent sends an event to the client
-func (c *Client) sendEvent(ctx context.Context, channel string, anonID int, arguments ...any) error {
+func (c *Client) sendEvent(
+	ctx context.Context, channel string, anonID int, arguments ...any,
+) error {
 	c.connReqMu.Lock()
 	conn := c.conn
 	c.connReqMu.Unlock()
@@ -433,7 +446,9 @@ func (c *Client) sendRequest(
 		}
 		return resp.Data, resp.Error
 	case <-ctxClient.Done():
-		return nil, fmt.Errorf("awaiting response: %w", context.Cause(ctxClient))
+		return nil, fmt.Errorf(
+			"awaiting response: %w", context.Cause(ctxClient),
+		)
 	case <-ctx.Done():
 		cancelCause := context.Cause(ctx)
 		_ = c.sendCancel(ctxClient, &requestID, cancelCause)
@@ -570,10 +585,13 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// Get message event name if any
 	eventName := msg.EventName()
 	if eventName != "" {
-		return c.handleEvent(ctx, msg, eventName, msg.Channel, msg.AnonymousChannel)
+		return c.handleEvent(
+			ctx, msg, eventName, msg.Channel, msg.AnonymousChannel,
+		)
 	}
 	// defer close(msg.processed) cannot go to the top of this function because
-	// handleEvent creates a goroutine that is responsible for closing msg.processed.
+	// handleEvent creates a goroutine that is responsible for closing
+	// msg.processed.
 	defer close(msg.processed)
 
 	// Inbound anonymous channel abort: {h, x} (no RequestID needed)
@@ -649,8 +667,11 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 // chanID is the string channel name for named channels, or "" for anonymous
 // channels (anonID is used for map lookups and abort messages in that case).
 func (c *Client) handleEvent(
-	ctx context.Context, msg Message, eventName string,
-	chanID string, anonID int,
+	ctx context.Context,
+	msg Message,
+	eventName string,
+	chanID string,
+	anonID int,
 ) error {
 	var cancel context.CancelCauseFunc
 
@@ -670,9 +691,12 @@ func (c *Client) handleEvent(
 		}
 	}
 
-	// Look up handler (client-specific first). For anonymous channels chanID is
-	// "" so the Channel field is empty and AnonymousChannel holds the numeric ID.
-	handlerID := handlerName{Channel: chanID, AnonymousChannel: anonID, Event: eventName}
+	// Look up handler (client-specific first). For anonymous channels chanID
+	// is "" so the Channel field is empty and AnonymousChannel holds the
+	// numeric ID.
+	handlerID := handlerName{
+		Channel: chanID, AnonymousChannel: anonID, Event: eventName,
+	}
 	c.handlersMu.Lock()
 	handler, ok := c.handlersOnce[handlerID]
 	if ok {
@@ -682,7 +706,8 @@ func (c *Client) handleEvent(
 	}
 	c.handlersMu.Unlock()
 
-	// For regular channels, get handlerCtxFunc and fall back to server handlers.
+	// For regular channels, get handlerCtxFunc and fall back to server
+	// handlers.
 	var handlerCtxFunc HandlerContextFunc
 	if c.server != nil {
 		c.server.handlersMu.Lock()
@@ -703,12 +728,17 @@ func (c *Client) handleEvent(
 		defer close(msg.processed)
 		var err error
 		if anonID != 0 {
-			err = fmt.Errorf("no event listener for '%s' on anonymous channel %d", eventName, anonID)
+			err = fmt.Errorf(
+				"no event listener for '%s' on anonymous channel %d",
+				eventName, anonID,
+			)
 		} else if chanID == "" {
 			// chanID is "" for the main (unnamed) channel
 			err = fmt.Errorf("no event listener for '%s'", eventName)
 		} else {
-			err = fmt.Errorf("no event listener for '%s' on channel '%s'", eventName, chanID)
+			err = fmt.Errorf(
+				"no event listener for '%s' on channel '%s'", eventName, chanID,
+			)
 		}
 		if msg.RequestID != nil {
 			return c.sendReject(ctx, msg.RequestID, err)
@@ -732,12 +762,14 @@ func (c *Client) handleEvent(
 		c.inboundCancelsMu.Unlock()
 
 		newChanID = *msg.RequestID
-		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, func() *AnonymousChannel {
-			if anonChan == nil {
-				anonChan = newAnonymousChannel(ctx, newChanID, c)
-			}
-			return anonChan
-		})
+		handlerCtx = context.WithValue(
+			handlerCtx, anonChannelKey{}, func() *AnonymousChannel {
+				if anonChan == nil {
+					anonChan = newAnonymousChannel(ctx, newChanID, c)
+				}
+				return anonChan
+			},
+		)
 	}
 
 	go func() {
@@ -747,9 +779,9 @@ func (c *Client) handleEvent(
 			cancel(context.Canceled)
 		}
 
-		// For event messages (not requests), clean up any factory channel that was
-		// created but not returned, then return. inboundCancels is only populated
-		// for requests, so there is nothing to remove here.
+		// For event messages (not requests), clean up any factory channel that
+		// was created but not returned, then return. inboundCancels is only
+		// populated for requests, so there is nothing to remove here.
 		if msg.RequestID == nil {
 			if anonChan != nil {
 				anonChan.closeWithCause(context.Canceled)
@@ -774,14 +806,15 @@ func (c *Client) handleEvent(
 			}
 			sendErr = c.sendReject(ctx, msg.RequestID, err)
 		} else if result == anonChan && anonChan != nil {
-			// Handler returned the factory anonymous channel; register and notify
+			// Handler returned the factory anonymous channel; register and
+			// notify
 			c.connReqMu.Lock()
 			c.anonChans[newChanID] = anonChan
 			c.connReqMu.Unlock()
 			sendErr = c.sendResolveAnon(ctx, msg.RequestID)
 		} else {
-			// Handler returned a regular value (or nil / a different anon channel);
-			// close the factory channel if one was created
+			// Handler returned a regular value (or nil / a different anon
+			// channel); close the factory channel if one was created
 			if anonChan != nil {
 				anonChan.closeWithCause(context.Canceled)
 			}

--- a/client.go
+++ b/client.go
@@ -596,9 +596,9 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// Inbound anonymous channel abort: {h, x} (no RequestID needed)
 	if msg.AnonymousChannel != 0 && msg.CancelReason != nil {
 		c.connReqMu.Lock()
-		ch, ok := c.anonChans[msg.AnonymousChannel]
+		ch := c.anonChans[msg.AnonymousChannel]
 		c.connReqMu.Unlock()
-		if ok {
+		if ch != nil {
 			ch.closeWithCause(msg.CancelCause())
 		}
 		return nil
@@ -666,8 +666,6 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 func (c *Client) handleEvent(
 	ctx context.Context, msg Message, eventName string,
 ) error {
-	var cancel context.CancelCauseFunc
-
 	// For anonymous channels, verify the channel exists; send abort if not.
 	if anonID := msg.AnonymousChannel; anonID != 0 {
 		c.connReqMu.Lock()
@@ -750,21 +748,20 @@ func (c *Client) handleEvent(
 		}
 		handlerCtx = handlerCtxFunc(ctx, handlerCtxChanName, eventName)
 	}
-	// For inbound requests, create a cancellable context and inject the
-	// anonymous channel factory so handlers can call Channel(ctx).
+	// For inbound requests, create a request-specific cancellable context and
+	// inject the anonymous channel factory, so handlers can call Channel(ctx).
+	var cancel context.CancelCauseFunc
 	var anonChan *AnonymousChannel
-	var newChanID int
 	if msg.RequestID != nil {
 		handlerCtx, cancel = context.WithCancelCause(handlerCtx)
 		c.inboundCancelsMu.Lock()
 		c.inboundCancels[*msg.RequestID] = cancel
 		c.inboundCancelsMu.Unlock()
 
-		newChanID = *msg.RequestID
 		handlerCtx = context.WithValue(
 			handlerCtx, anonChannelKey{}, func() *AnonymousChannel {
 				if anonChan == nil {
-					anonChan = newAnonymousChannel(ctx, newChanID, c)
+					anonChan = newAnonymousChannel(ctx, *msg.RequestID, c)
 				}
 				return anonChan
 			},
@@ -808,7 +805,7 @@ func (c *Client) handleEvent(
 			// Handler returned the factory anonymous channel; register and
 			// notify
 			c.connReqMu.Lock()
-			c.anonChans[newChanID] = anonChan
+			c.anonChans[*msg.RequestID] = anonChan
 			c.connReqMu.Unlock()
 			sendErr = c.sendResolveAnon(ctx, msg.RequestID)
 		} else {

--- a/client.go
+++ b/client.go
@@ -26,7 +26,7 @@ type Client struct {
 	conn              Conn            // WebSocket connection; set `nil` on close
 	requestID         int             // auto-incrementing request ID
 	requestResponseCh map[int]chan messageResponse
-	anonChans         map[string]*AnonymousChannel
+	anonChans         map[int]*AnonymousChannel
 	inboundCancelsMu  sync.Mutex
 	inboundCancels    map[int]func(error) // cancel funcs for inbound requests
 	handlersMu        sync.Mutex          // protects handlers and handlersOnce
@@ -61,7 +61,7 @@ func NewClient(conn Conn) *Client {
 		// ClientChannel is set below
 		// ctx, ctxCancel, and conn are assigned in Bind method
 		requestResponseCh: make(map[int]chan messageResponse),
-		anonChans:         make(map[string]*AnonymousChannel),
+		anonChans:         make(map[int]*AnonymousChannel),
 		inboundCancels:    make(map[int]func(error)),
 		handlers:          make(map[handlerName]any),
 		handlersOnce:      make(map[handlerName]any),
@@ -128,7 +128,7 @@ func (c *Client) Bind(conn Conn) {
 	c.ctx, c.ctxCancel = context.WithCancelCause(context.Background())
 	c.ctx = context.WithValue(c.ctx, clientKey{}, c)
 	prevAnonChans := c.anonChans
-	c.anonChans = make(map[string]*AnonymousChannel)
+	c.anonChans = make(map[int]*AnonymousChannel)
 	c.connReqMu.Unlock()
 
 	// Close previous connection / anonymous channels
@@ -194,7 +194,7 @@ func (c *Client) close(
 	}
 	clear(c.requestResponseCh)
 	anonChans := c.anonChans
-	c.anonChans = make(map[string]*AnonymousChannel)
+	c.anonChans = make(map[int]*AnonymousChannel)
 	c.connReqMu.Unlock()
 
 	// Close all anonymous channels (snapshot-clear-then-close to avoid deadlock).
@@ -288,7 +288,7 @@ func (c *Client) sendCancel(
 }
 
 // sendAnonCancel sends an anonymous channel abort message to the client.
-func (c *Client) sendAnonCancel(ctx context.Context, chanID string, reason error) error {
+func (c *Client) sendAnonCancel(ctx context.Context, chanID int, reason error) error {
 	if reason == nil {
 		reason = context.Canceled
 	}
@@ -299,7 +299,7 @@ func (c *Client) sendAnonCancel(ctx context.Context, chanID string, reason error
 		return errClosed
 	}
 	return conn.WriteMessage(ctx, &Message{
-		AnonymousChannel: anonChannelH(chanID),
+		AnonymousChannel: chanID,
 		ResponseJSError:  true,
 		CancelReason: map[string]any{
 			"message": reason.Error(),
@@ -324,8 +324,9 @@ func (c *Client) sendResolve(ctx context.Context, requestID *int, data any) erro
 	})
 }
 
-// sendResolveAnon sends an anonymous channel creation response to the client.
-func (c *Client) sendResolveAnon(ctx context.Context, requestID *int, chanID string) error {
+// sendResolveAnon sends an anonymous channel creation response {i, h:1} to
+// the client. The channel ID is inferred from i on the remote end.
+func (c *Client) sendResolveAnon(ctx context.Context, requestID *int) error {
 	c.connReqMu.Lock()
 	conn := c.conn
 	c.connReqMu.Unlock()
@@ -334,12 +335,12 @@ func (c *Client) sendResolveAnon(ctx context.Context, requestID *int, chanID str
 	}
 	return conn.WriteMessage(ctx, &Message{
 		RequestID:        requestID,
-		AnonymousChannel: anonChannelH(chanID),
+		AnonymousChannel: 1,
 	})
 }
 
 // sendEvent sends an event to the client
-func (c *Client) sendEvent(ctx context.Context, channel string, anonymous bool, arguments ...any) error {
+func (c *Client) sendEvent(ctx context.Context, channel string, anonID int, arguments ...any) error {
 	c.connReqMu.Lock()
 	conn := c.conn
 	c.connReqMu.Unlock()
@@ -357,8 +358,8 @@ func (c *Client) sendEvent(ctx context.Context, channel string, anonymous bool, 
 	}
 	// Send event to client
 	msg := &Message{Arguments: jsonArgs}
-	if anonymous {
-		msg.AnonymousChannel = anonChannelH(channel)
+	if anonID != 0 {
+		msg.AnonymousChannel = anonID
 	} else {
 		msg.Channel = channel
 	}
@@ -367,7 +368,7 @@ func (c *Client) sendEvent(ctx context.Context, channel string, anonymous bool, 
 
 // sendRequest sends a request to the client and returns the response
 func (c *Client) sendRequest(
-	ctx context.Context, channel string, anonymous bool, arguments ...any,
+	ctx context.Context, channel string, anonID int, arguments ...any,
 ) (any, error) {
 	c.connReqMu.Lock()
 	conn := c.conn
@@ -402,8 +403,8 @@ func (c *Client) sendRequest(
 
 	// Send request to client
 	msg := &Message{Arguments: jsonArgs, RequestID: &requestID}
-	if anonymous {
-		msg.AnonymousChannel = anonChannelH(channel)
+	if anonID != 0 {
+		msg.AnonymousChannel = anonID
 	} else {
 		msg.Channel = channel
 	}
@@ -560,20 +561,19 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// Get message event name if any
 	eventName := msg.EventName()
 	if eventName != "" {
+		anonID := msg.AnonymousChannel
 		chanID := msg.Channel
-		anonymous := msg.AnonymousChannel != ""
-		if anonymous {
-			chanID = string(msg.AnonymousChannel)
+		if anonID != 0 {
+			chanID = strconv.Itoa(anonID)
 		}
-		return c.handleInboundMessage(ctx, msg, eventName, chanID, anonymous)
+		return c.handleInboundMessage(ctx, msg, eventName, chanID, anonID)
 	}
 	defer close(msg.processed)
 
 	// Inbound anonymous channel abort: {h, x} (no RequestID needed)
-	if msg.AnonymousChannel != "" && msg.CancelReason != nil {
-		chanID := string(msg.AnonymousChannel)
+	if msg.AnonymousChannel != 0 && msg.CancelReason != nil {
 		c.connReqMu.Lock()
-		ch, ok := c.anonChans[chanID]
+		ch, ok := c.anonChans[msg.AnonymousChannel]
 		c.connReqMu.Unlock()
 		if ok {
 			ch.closeWithCause(msg.parseCancelReason())
@@ -587,8 +587,8 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	}
 
 	// Anonymous channel creation response: {i, h} (no CancelReason, no Arguments)
-	if msg.AnonymousChannel != "" && msg.CancelReason == nil {
-		chanID := strconv.Itoa(*msg.RequestID)
+	if msg.AnonymousChannel != 0 && msg.CancelReason == nil {
+		chanID := *msg.RequestID
 		c.connReqMu.Lock()
 		respCh, ok := c.requestResponseCh[*msg.RequestID]
 		if ok {
@@ -639,23 +639,23 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 }
 
 // handleInboundMessage handles an inbound event or request on any channel.
-// chanID is the channel name (msg.Channel for regular, string(msg.AnonymousChannel)
-// for anonymous). anonymous mirrors the handlerName.Anonymous flag.
+// chanID is the string channel name for handler routing; anonID is non-zero for
+// anonymous channels and is used for map lookups and abort messages.
 func (c *Client) handleInboundMessage(
 	ctx context.Context, msg Message, eventName string,
-	chanID string, anonymous bool,
+	chanID string, anonID int,
 ) error {
 	var cancel context.CancelCauseFunc
 
 	// For anonymous channels, verify the channel exists; send abort if not.
-	if anonymous {
+	if anonID != 0 {
 		c.connReqMu.Lock()
-		_, ok := c.anonChans[chanID]
+		_, ok := c.anonChans[anonID]
 		c.connReqMu.Unlock()
 		if !ok {
 			defer close(msg.processed)
 			err := fmt.Errorf("anonymous channel '%s' not found", chanID)
-			_ = c.sendAnonCancel(ctx, chanID, err)
+			_ = c.sendAnonCancel(ctx, anonID, err)
 			if msg.RequestID != nil {
 				return c.sendReject(ctx, msg.RequestID, err)
 			}
@@ -664,7 +664,7 @@ func (c *Client) handleInboundMessage(
 	}
 
 	// Look up handler (client-specific first)
-	handlerID := handlerName{Channel: chanID, Anonymous: anonymous, Event: eventName}
+	handlerID := handlerName{Channel: chanID, Anonymous: anonID != 0, Event: eventName}
 	c.handlersMu.Lock()
 	handler, ok := c.handlersOnce[handlerID]
 	if ok {
@@ -679,7 +679,7 @@ func (c *Client) handleInboundMessage(
 	if c.server != nil {
 		c.server.handlersMu.Lock()
 		handlerCtxFunc = c.server.handlerCtxFunc
-		if !anonymous && handler == nil {
+		if anonID == 0 && handler == nil {
 			handler, ok = c.server.handlersOnce[handlerID]
 			if ok {
 				delete(c.server.handlersOnce, handlerID)
@@ -711,14 +711,14 @@ func (c *Client) handleInboundMessage(
 	// For inbound requests, create a cancellable context and inject the
 	// anonymous channel factory so handlers can call Channel(ctx).
 	var anonChan *AnonymousChannel
-	var newChanID string
+	var newChanID int
 	if msg.RequestID != nil {
 		handlerCtx, cancel = context.WithCancelCause(handlerCtx)
 		c.inboundCancelsMu.Lock()
 		c.inboundCancels[*msg.RequestID] = cancel
 		c.inboundCancelsMu.Unlock()
 
-		newChanID = strconv.Itoa(*msg.RequestID)
+		newChanID = *msg.RequestID
 		factory := func() *AnonymousChannel {
 			if anonChan == nil {
 				anonChan = newAnonymousChannel(ctx, newChanID, c)
@@ -751,7 +751,7 @@ func (c *Client) handleInboundMessage(
 			c.connReqMu.Lock()
 			c.anonChans[newChanID] = anon
 			c.connReqMu.Unlock()
-			sendErr := c.sendResolveAnon(ctx, msg.RequestID, newChanID)
+			sendErr := c.sendResolveAnon(ctx, msg.RequestID)
 			if sendErr != nil {
 				sendErr = fmt.Errorf("responding to request: %w", sendErr)
 				c.emitError(sendErr)

--- a/client.go
+++ b/client.go
@@ -17,24 +17,33 @@ var errRebound = errors.New("client bound to new connection")
 // errClosed is returned when an operation is attempted on a closed connection.
 var errClosed = errors.New("connection closed")
 
+// outboundRequest tracks a pending outbound request, pairing the response
+// channel with the context that was passed to Request/sendRequest. The context
+// is used to abort the resulting AnonymousChannel if the caller cancels before
+// the channel is closed.
+type outboundRequest struct {
+	respCh chan messageResponse
+	ctx    context.Context
+}
+
 // Client represents a WebSocket client
 type Client struct {
-	ClientChannel                     // the "main" client channel with no name
-	connReqMu         sync.Mutex      // protects ctx, Conn, requests, and anonChans
-	ctx               context.Context // cancelled when the connection is closed
-	ctxCancel         func(error)     // called when the connection is closed
-	conn              Conn            // WebSocket connection; set `nil` on close
-	requestID         int             // auto-incrementing request ID
-	requestResponseCh map[int]chan messageResponse
-	anonChans         map[int]*AnonymousChannel
-	inboundCancelsMu  sync.Mutex
-	inboundCancels    map[int]func(error) // cancel funcs for inbound requests
-	handlersMu        sync.Mutex          // protects handlers and handlersOnce
-	handlers          map[handlerName]any
-	handlersOnce      map[handlerName]any
-	dataMu            sync.Mutex
-	data              map[string]any
-	server            *Server // server associated with the Client
+	ClientChannel                    // the "main" client channel with no name
+	connReqMu        sync.Mutex      // protects ctx, Conn, requests, and anonChans
+	ctx              context.Context // cancelled when the connection is closed
+	ctxCancel        func(error)     // called when the connection is closed
+	conn             Conn            // WebSocket connection; set `nil` on close
+	requestID        int             // auto-incrementing request ID
+	outboundRequests map[int]outboundRequest
+	anonChans        map[int]*AnonymousChannel
+	inboundCancelsMu sync.Mutex
+	inboundCancels   map[int]func(error) // cancel funcs for inbound requests
+	handlersMu       sync.Mutex          // protects handlers and handlersOnce
+	handlers         map[handlerName]any
+	handlersOnce     map[handlerName]any
+	dataMu           sync.Mutex
+	data             map[string]any
+	server           *Server // server associated with the Client
 }
 
 // NewClient creates a new Client not associated with any Server. Register
@@ -60,12 +69,12 @@ func NewClient(conn Conn) *Client {
 	c := &Client{
 		// ClientChannel is set below
 		// ctx, ctxCancel, and conn are assigned in Bind method
-		requestResponseCh: make(map[int]chan messageResponse),
-		anonChans:         make(map[int]*AnonymousChannel),
-		inboundCancels:    make(map[int]func(error)),
-		handlers:          make(map[handlerName]any),
-		handlersOnce:      make(map[handlerName]any),
-		data:              make(map[string]any),
+		outboundRequests: make(map[int]outboundRequest),
+		anonChans:        make(map[int]*AnonymousChannel),
+		inboundCancels:   make(map[int]func(error)),
+		handlers:         make(map[handlerName]any),
+		handlersOnce:     make(map[handlerName]any),
+		data:             make(map[string]any),
 		// server is set only by Server.Accept
 	}
 	// Set channel reference back to client, so channel methods work properly
@@ -120,11 +129,11 @@ func (c *Client) Bind(conn Conn) {
 
 	// Abort any pending outbound requests; their responses will never arrive
 	// on the new connection.
-	for _, respCh := range c.requestResponseCh {
-		respCh <- messageResponse{nil, errRebound}
-		close(respCh)
+	for _, req := range c.outboundRequests {
+		req.respCh <- messageResponse{nil, errRebound}
+		close(req.respCh)
 	}
-	clear(c.requestResponseCh)
+	clear(c.outboundRequests)
 
 	// Create a context that is cancelled when the connection is closed.
 	// I know it is generally frowned upon to store the Context in a struct, but
@@ -194,11 +203,11 @@ func (c *Client) close(
 	c.ctxCancel(fmt.Errorf("client closed (status: %v)", status))
 	c.conn = nil
 	// Abort all pending outbound requests for this client.
-	for _, respCh := range c.requestResponseCh {
-		respCh <- messageResponse{nil, errClosed}
-		close(respCh)
+	for _, req := range c.outboundRequests {
+		req.respCh <- messageResponse{nil, errClosed}
+		close(req.respCh)
 	}
-	clear(c.requestResponseCh)
+	clear(c.outboundRequests)
 	anonChans := c.anonChans
 	c.anonChans = make(map[int]*AnonymousChannel)
 	c.connReqMu.Unlock()
@@ -268,7 +277,7 @@ func (c *Client) sendReject(
 }
 
 // sendCancel sends a cancellation signal for a request and removes it from
-// requestResponseCh.
+// outboundRequests.
 func (c *Client) sendCancel(
 	ctx context.Context,
 	requestID *int,
@@ -278,8 +287,8 @@ func (c *Client) sendCancel(
 		reason = errors.New("Request aborted")
 	}
 	c.connReqMu.Lock()
-	_, ok := c.requestResponseCh[*requestID]
-	delete(c.requestResponseCh, *requestID)
+	_, ok := c.outboundRequests[*requestID]
+	delete(c.outboundRequests, *requestID)
 	conn := c.conn
 	c.connReqMu.Unlock()
 	if !ok || conn == nil {
@@ -405,12 +414,12 @@ func (c *Client) sendRequest(
 	// Add channel to client's pending requests and get unique request ID
 	c.requestID++
 	requestID := c.requestID
-	if c.requestResponseCh[requestID] != nil {
+	if _, ok := c.outboundRequests[requestID]; ok {
 		// should never happen
 		c.connReqMu.Unlock()
 		return nil, fmt.Errorf("request ID %d already in use", requestID)
 	} else {
-		c.requestResponseCh[requestID] = respCh
+		c.outboundRequests[requestID] = outboundRequest{respCh: respCh, ctx: ctx}
 		c.connReqMu.Unlock()
 	}
 
@@ -434,7 +443,7 @@ func (c *Client) sendRequest(
 	err := conn.WriteMessage(ctx, msg)
 	if err != nil {
 		c.connReqMu.Lock()
-		delete(c.requestResponseCh, requestID)
+		delete(c.outboundRequests, requestID)
 		c.connReqMu.Unlock()
 		return nil, fmt.Errorf("sending request: %w", err)
 	}
@@ -613,19 +622,21 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// was handled above so it is nil here)
 	if msg.AnonymousChannel != 0 {
 		c.connReqMu.Lock()
-		respCh, ok := c.requestResponseCh[*msg.RequestID]
+		req, ok := c.outboundRequests[*msg.RequestID]
+		var anon *AnonymousChannel
 		if ok {
-			delete(c.requestResponseCh, *msg.RequestID)
+			chanID := *msg.RequestID
+			anon = newAnonymousChannel(ctx, req.ctx, chanID, c)
+			anon.ready = true // requestor receives a ready channel
+			delete(c.outboundRequests, *msg.RequestID)
+			c.anonChans[chanID] = anon
 		}
-		chanID := *msg.RequestID
-		anon := newAnonymousChannel(ctx, chanID, c)
-		c.anonChans[chanID] = anon
 		c.connReqMu.Unlock()
-		if respCh == nil {
+		if !ok {
 			return nil // ignore message with invalid request ID
 		}
-		respCh <- messageResponse{anon, nil}
-		close(respCh)
+		req.respCh <- messageResponse{anon, nil}
+		close(req.respCh)
 		return nil
 	}
 
@@ -643,21 +654,21 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 		return nil
 	}
 
-	// Get request handler
+	// Get outbound request handler
 	c.connReqMu.Lock()
-	respCh, ok := c.requestResponseCh[*msg.RequestID]
+	req, ok := c.outboundRequests[*msg.RequestID]
 	if ok {
-		delete(c.requestResponseCh, *msg.RequestID)
+		delete(c.outboundRequests, *msg.RequestID)
 	}
 	c.connReqMu.Unlock()
-	if respCh == nil {
+	if !ok {
 		return nil // ignore message with invalid request ID
 	}
 
 	// Process response
 	res, err := msg.Response()
-	respCh <- messageResponse{res, err}
-	close(respCh)
+	req.respCh <- messageResponse{res, err}
+	close(req.respCh)
 
 	return nil
 }
@@ -761,9 +772,9 @@ func (c *Client) handleEvent(
 		handlerCtx = context.WithValue(
 			handlerCtx, anonChannelKey{}, func() *AnonymousChannel {
 				if anonChan == nil {
-					// Anonymous channel uses connection context, not request
-					// context
-					anonChan = newAnonymousChannel(ctx, *msg.RequestID, c)
+					// Inbound anonymous channels are not tied to a request
+					// context, so pass context.Background() as reqCtx.
+					anonChan = newAnonymousChannel(ctx, context.Background(), *msg.RequestID, c)
 				}
 				return anonChan
 			},
@@ -812,6 +823,9 @@ func (c *Client) handleEvent(
 			c.anonChans[*msg.RequestID] = anonChan
 			c.connReqMu.Unlock()
 			sendErr = c.sendResolveAnon(ctx, msg.RequestID)
+			if sendErr == nil {
+				anonChan.ready = true
+			}
 		} else {
 			// Clean up the anonymous channel if one was created
 			if anonChan != nil {

--- a/client.go
+++ b/client.go
@@ -17,19 +17,18 @@ var errRebound = errors.New("client bound to new connection")
 // Client represents a WebSocket client
 type Client struct {
 	ClientChannel                     // the "main" client channel with no name
-	connReqMu         sync.Mutex      // protects Context, Conn, and request stuff
+	connReqMu         sync.Mutex      // protects Context, Conn, requests, and anonChans
 	ctx               context.Context // cancelled when the connection is closed
 	ctxCancel         func(error)     // called when the connection is closed
 	conn              Conn            // WebSocket connection; set `nil` on close
 	requestID         int             // auto-incrementing request ID
 	requestResponseCh map[int]chan messageResponse
+	anonChans         map[string]*AnonymousChannel
 	inboundCancelsMu  sync.Mutex
 	inboundCancels    map[int]func(error) // cancel funcs for inbound requests
-	handlersMu        sync.Mutex
+	handlersMu        sync.Mutex          // protects handlers and handlersOnce
 	handlers          map[handlerName]any
 	handlersOnce      map[handlerName]any
-	anonChansMu       sync.Mutex
-	anonChans         map[string]*AnonymousChannel
 	dataMu            sync.Mutex
 	data              map[string]any
 	server            *Server // server associated with the Client
@@ -125,13 +124,9 @@ func (c *Client) Bind(conn Conn) {
 	// cancellation.
 	c.ctx, c.ctxCancel = context.WithCancelCause(context.Background())
 	c.ctx = context.WithValue(c.ctx, clientKey{}, c)
-	c.connReqMu.Unlock()
-
-	// Close all anonymous channels from the previous connection.
-	c.anonChansMu.Lock()
 	prevAnonChans := c.anonChans
 	c.anonChans = make(map[string]*AnonymousChannel)
-	c.anonChansMu.Unlock()
+	c.connReqMu.Unlock()
 	for _, ch := range prevAnonChans {
 		ch.closeWithCause(errRebound)
 	}
@@ -191,13 +186,11 @@ func (c *Client) close(
 		close(respCh)
 	}
 	clear(c.requestResponseCh)
+	anonChans := c.anonChans
+	c.anonChans = make(map[string]*AnonymousChannel)
 	c.connReqMu.Unlock()
 
 	// Close all anonymous channels (snapshot-clear-then-close to avoid deadlock).
-	c.anonChansMu.Lock()
-	anonChans := c.anonChans
-	c.anonChans = make(map[string]*AnonymousChannel)
-	c.anonChansMu.Unlock()
 	for _, ch := range anonChans {
 		ch.closeWithCause(fmt.Errorf("connection closed"))
 	}
@@ -569,9 +562,9 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// Inbound anonymous channel abort: {h, x} (no RequestID needed)
 	if msg.AnonymousChannel != "" && msg.CancelReason != nil {
 		chanID := string(msg.AnonymousChannel)
-		c.anonChansMu.Lock()
+		c.connReqMu.Lock()
 		ch, ok := c.anonChans[chanID]
-		c.anonChansMu.Unlock()
+		c.connReqMu.Unlock()
 		if ok {
 			ch.closeWithCause(msg.parseCancelReason())
 		}
@@ -591,14 +584,12 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 		if ok {
 			delete(c.requestResponseCh, *msg.RequestID)
 		}
+		anon := newAnonymousChannel(ctx, chanID, c)
+		c.anonChans[chanID] = anon
 		c.connReqMu.Unlock()
 		if respCh == nil {
 			return nil
 		}
-		anon := newAnonymousChannel(chanID, c)
-		c.anonChansMu.Lock()
-		c.anonChans[chanID] = anon
-		c.anonChansMu.Unlock()
 		respCh <- messageResponse{anon, nil}
 		close(respCh)
 		return nil
@@ -698,7 +689,7 @@ func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventNam
 	}
 	// For inbound requests, create a request-specific cancellable context and
 	// inject the anonymous channel factory.
-	var factoryChan *AnonymousChannel
+	var anonChan *AnonymousChannel
 	if msg.RequestID != nil {
 		handlerCtx, cancel = context.WithCancelCause(handlerCtx)
 		// Save the CancelCauseFunc for the request
@@ -709,10 +700,10 @@ func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventNam
 		// Inject anonymous channel factory so the handler can call Channel(ctx)
 		chanID := strconv.Itoa(*msg.RequestID)
 		factory := func() *AnonymousChannel {
-			if factoryChan == nil {
-				factoryChan = newAnonymousChannel(chanID, c)
+			if anonChan == nil {
+				anonChan = newAnonymousChannel(ctx, chanID, c)
 			}
-			return factoryChan
+			return anonChan
 		}
 		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, factory)
 	}
@@ -730,8 +721,8 @@ func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventNam
 
 		if msg.RequestID == nil {
 			// Silently ignore the response if it's not a request
-			if factoryChan != nil {
-				factoryChan.ctxCancel(context.Canceled) // cleanup unused factory
+			if anonChan != nil {
+				anonChan.ctxCancel(context.Canceled) // cleanup unused factory
 			}
 			return
 		}
@@ -744,10 +735,10 @@ func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventNam
 		chanID := strconv.Itoa(*msg.RequestID)
 
 		// Check if handler returned the factory anonymous channel
-		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == factoryChan {
-			c.anonChansMu.Lock()
+		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == anonChan {
+			c.connReqMu.Lock()
 			c.anonChans[chanID] = anon
-			c.anonChansMu.Unlock()
+			c.connReqMu.Unlock()
 			sendErr := c.sendAnonCreation(ctx, msg.RequestID, chanID)
 			if sendErr != nil {
 				sendErr = fmt.Errorf("responding to request: %w", sendErr)
@@ -760,8 +751,8 @@ func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventNam
 			return
 		}
 		// Clean up unused factory channel if one was created
-		if factoryChan != nil {
-			factoryChan.ctxCancel(context.Canceled)
+		if anonChan != nil {
+			anonChan.ctxCancel(context.Canceled)
 		}
 
 		if err != nil {
@@ -791,9 +782,9 @@ func (c *Client) handleAnonChannelMessage(ctx context.Context, msg Message, even
 	chanID := string(msg.AnonymousChannel)
 
 	// Lookup the anonymous channel
-	c.anonChansMu.Lock()
+	c.connReqMu.Lock()
 	_, ok := c.anonChans[chanID]
-	c.anonChansMu.Unlock()
+	c.connReqMu.Unlock()
 	if !ok {
 		// Unknown anonymous channel: notify remote and reject any sub-request
 		defer close(msg.processed)
@@ -841,7 +832,7 @@ func (c *Client) handleAnonChannelMessage(ctx context.Context, msg Message, even
 	}
 	// For inbound sub-requests on anonymous channels, create a cancellable
 	// context and inject a nested anonymous channel factory.
-	var factoryChan *AnonymousChannel
+	var anonChan *AnonymousChannel
 	if msg.RequestID != nil {
 		handlerCtx, anonCancel = context.WithCancelCause(handlerCtx)
 		c.inboundCancelsMu.Lock()
@@ -850,10 +841,10 @@ func (c *Client) handleAnonChannelMessage(ctx context.Context, msg Message, even
 
 		subChanID := strconv.Itoa(*msg.RequestID)
 		factory := func() *AnonymousChannel {
-			if factoryChan == nil {
-				factoryChan = newAnonymousChannel(subChanID, c)
+			if anonChan == nil {
+				anonChan = newAnonymousChannel(ctx, subChanID, c)
 			}
-			return factoryChan
+			return anonChan
 		}
 		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, factory)
 	}
@@ -865,8 +856,8 @@ func (c *Client) handleAnonChannelMessage(ctx context.Context, msg Message, even
 			anonCancel(context.Canceled)
 		}
 		if msg.RequestID == nil {
-			if factoryChan != nil {
-				factoryChan.ctxCancel(context.Canceled)
+			if anonChan != nil {
+				anonChan.ctxCancel(context.Canceled)
 			}
 			return
 		}
@@ -877,10 +868,10 @@ func (c *Client) handleAnonChannelMessage(ctx context.Context, msg Message, even
 		subChanID := strconv.Itoa(*msg.RequestID)
 
 		// Check if handler returned the factory anonymous channel
-		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == factoryChan {
-			c.anonChansMu.Lock()
+		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == anonChan {
+			c.connReqMu.Lock()
 			c.anonChans[subChanID] = anon
-			c.anonChansMu.Unlock()
+			c.connReqMu.Unlock()
 			sendErr := c.sendAnonCreation(ctx, msg.RequestID, subChanID)
 			if sendErr != nil {
 				sendErr = fmt.Errorf("responding to request: %w", sendErr)
@@ -892,8 +883,8 @@ func (c *Client) handleAnonChannelMessage(ctx context.Context, msg Message, even
 			}
 			return
 		}
-		if factoryChan != nil {
-			factoryChan.ctxCancel(context.Canceled)
+		if anonChan != nil {
+			anonChan.ctxCancel(context.Canceled)
 		}
 
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"sync"
 )
 
@@ -287,24 +286,34 @@ func (c *Client) sendCancel(
 	})
 }
 
-// sendAnonCancel sends an anonymous channel abort message to the client.
+// sendAnonCancel sends an anonymous channel abort message to the client and
+// closes the anonymous channel, mirroring how sendCancel removes an outbound
+// request from requestResponseCh.
 func (c *Client) sendAnonCancel(ctx context.Context, chanID int, reason error) error {
 	if reason == nil {
 		reason = context.Canceled
 	}
 	c.connReqMu.Lock()
+	ch := c.anonChans[chanID]
 	conn := c.conn
 	c.connReqMu.Unlock()
 	if conn == nil {
+		if ch != nil {
+			ch.closeWithCause(reason)
+		}
 		return errClosed
 	}
-	return conn.WriteMessage(ctx, &Message{
+	err := conn.WriteMessage(ctx, &Message{
 		AnonymousChannel: chanID,
 		ResponseJSError:  true,
 		CancelReason: map[string]any{
 			"message": reason.Error(),
 		},
 	})
+	if ch != nil {
+		ch.closeWithCause(reason)
+	}
+	return err
 }
 
 // sendResolve sends a resolve / data response to a request
@@ -561,13 +570,10 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// Get message event name if any
 	eventName := msg.EventName()
 	if eventName != "" {
-		anonID := msg.AnonymousChannel
-		chanID := msg.Channel
-		if anonID != 0 {
-			chanID = strconv.Itoa(anonID)
-		}
-		return c.handleInboundMessage(ctx, msg, eventName, chanID, anonID)
+		return c.handleEvent(ctx, msg, eventName, msg.Channel, msg.AnonymousChannel)
 	}
+	// defer close(msg.processed) cannot go to the top of this function because
+	// handleEvent creates a goroutine that is responsible for closing msg.processed.
 	defer close(msg.processed)
 
 	// Inbound anonymous channel abort: {h, x} (no RequestID needed)
@@ -576,7 +582,7 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 		ch, ok := c.anonChans[msg.AnonymousChannel]
 		c.connReqMu.Unlock()
 		if ok {
-			ch.closeWithCause(msg.parseCancelReason())
+			ch.closeWithCause(msg.CancelCause())
 		}
 		return nil
 	}
@@ -586,8 +592,9 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 		return nil // ignore message with no request ID
 	}
 
-	// Anonymous channel creation response: {i, h} (no CancelReason, no Arguments)
-	if msg.AnonymousChannel != 0 && msg.CancelReason == nil {
+	// Anonymous channel creation response: {i, h} (no Arguments; CancelReason
+	// was handled above so it is nil here)
+	if msg.AnonymousChannel != 0 {
 		chanID := *msg.RequestID
 		c.connReqMu.Lock()
 		respCh, ok := c.requestResponseCh[*msg.RequestID]
@@ -638,10 +645,10 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	return nil
 }
 
-// handleInboundMessage handles an inbound event or request on any channel.
-// chanID is the string channel name for handler routing; anonID is non-zero for
-// anonymous channels and is used for map lookups and abort messages.
-func (c *Client) handleInboundMessage(
+// handleEvent handles an inbound event or request on any channel.
+// chanID is the string channel name for named channels, or "" for anonymous
+// channels (anonID is used for map lookups and abort messages in that case).
+func (c *Client) handleEvent(
 	ctx context.Context, msg Message, eventName string,
 	chanID string, anonID int,
 ) error {
@@ -654,7 +661,7 @@ func (c *Client) handleInboundMessage(
 		c.connReqMu.Unlock()
 		if !ok {
 			defer close(msg.processed)
-			err := fmt.Errorf("anonymous channel '%s' not found", chanID)
+			err := fmt.Errorf("anonymous channel %d not found", anonID)
 			_ = c.sendAnonCancel(ctx, anonID, err)
 			if msg.RequestID != nil {
 				return c.sendReject(ctx, msg.RequestID, err)
@@ -663,13 +670,9 @@ func (c *Client) handleInboundMessage(
 		}
 	}
 
-	// Look up handler (client-specific first)
-	var handlerID handlerName
-	if anonID != 0 {
-		handlerID = handlerName{AnonymousChannel: anonID, Event: eventName}
-	} else {
-		handlerID = handlerName{Channel: chanID, Event: eventName}
-	}
+	// Look up handler (client-specific first). For anonymous channels chanID is
+	// "" so the Channel field is empty and AnonymousChannel holds the numeric ID.
+	handlerID := handlerName{Channel: chanID, AnonymousChannel: anonID, Event: eventName}
 	c.handlersMu.Lock()
 	handler, ok := c.handlersOnce[handlerID]
 	if ok {
@@ -698,9 +701,13 @@ func (c *Client) handleInboundMessage(
 	// Handle missing handler
 	if handler == nil {
 		defer close(msg.processed)
-		err := fmt.Errorf("no event listener for '%s' on channel '%s'", eventName, chanID)
-		if chanID == "" {
+		var err error
+		if anonID != 0 {
+			err = fmt.Errorf("no event listener for '%s' on anonymous channel %d", eventName, anonID)
+		} else if chanID == "" {
 			err = fmt.Errorf("no event listener for '%s'", eventName)
+		} else {
+			err = fmt.Errorf("no event listener for '%s' on channel '%s'", eventName, chanID)
 		}
 		if msg.RequestID != nil {
 			return c.sendReject(ctx, msg.RequestID, err)
@@ -724,13 +731,12 @@ func (c *Client) handleInboundMessage(
 		c.inboundCancelsMu.Unlock()
 
 		newChanID = *msg.RequestID
-		factory := func() *AnonymousChannel {
+		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, func() *AnonymousChannel {
 			if anonChan == nil {
 				anonChan = newAnonymousChannel(ctx, newChanID, c)
 			}
 			return anonChan
-		}
-		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, factory)
+		})
 	}
 
 	go func() {
@@ -740,9 +746,12 @@ func (c *Client) handleInboundMessage(
 			cancel(context.Canceled)
 		}
 
+		// For event messages (not requests), clean up any factory channel that was
+		// created but not returned, then return. inboundCancels is only populated
+		// for requests, so there is nothing to remove here.
 		if msg.RequestID == nil {
 			if anonChan != nil {
-				anonChan.ctxCancel(context.Canceled) // cleanup unused factory
+				anonChan.closeWithCause(context.Canceled)
 			}
 			return
 		}
@@ -751,39 +760,36 @@ func (c *Client) handleInboundMessage(
 		delete(c.inboundCancels, *msg.RequestID)
 		c.inboundCancelsMu.Unlock()
 
-		// Check if handler returned the factory anonymous channel
-		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == anonChan {
+		// Handle request response: check the handler error first, then decide
+		// whether the handler returned the factory anonymous channel.
+		var sendErr error
+		if err != nil {
+			// Handler returned an error; clean up any factory channel created
+			if anonChan != nil {
+				anonChan.closeWithCause(context.Canceled)
+			}
+			sendErr = c.sendReject(ctx, msg.RequestID, err)
+		} else if result == anonChan && anonChan != nil {
+			// Handler returned the factory anonymous channel; register and notify
 			c.connReqMu.Lock()
-			c.anonChans[newChanID] = anon
+			c.anonChans[newChanID] = anonChan
 			c.connReqMu.Unlock()
-			sendErr := c.sendResolveAnon(ctx, msg.RequestID)
-			if sendErr != nil {
-				sendErr = fmt.Errorf("responding to request: %w", sendErr)
-				c.emitError(sendErr)
-				if c.server != nil {
-					c.server.emitError(c, sendErr)
-				}
-				c.close(StatusInternalError, sendErr.Error(), false, false)
-			}
-			return
-		}
-		// Clean up unused factory channel if one was created
-		if anonChan != nil {
-			anonChan.ctxCancel(context.Canceled)
-		}
-
-		if err != nil {
-			err = c.sendReject(ctx, msg.RequestID, err)
+			sendErr = c.sendResolveAnon(ctx, msg.RequestID)
 		} else {
-			err = c.sendResolve(ctx, msg.RequestID, result)
-		}
-		if err != nil {
-			err = fmt.Errorf("responding to request: %w", err)
-			c.emitError(err)
-			if c.server != nil {
-				c.server.emitError(c, err)
+			// Handler returned a regular value (or nil / a different anon channel);
+			// close the factory channel if one was created
+			if anonChan != nil {
+				anonChan.closeWithCause(context.Canceled)
 			}
-			c.close(StatusInternalError, err.Error(), false, false)
+			sendErr = c.sendResolve(ctx, msg.RequestID, result)
+		}
+		if sendErr != nil {
+			sendErr = fmt.Errorf("responding to request: %w", sendErr)
+			c.emitError(sendErr)
+			if c.server != nil {
+				c.server.emitError(c, sendErr)
+			}
+			c.close(StatusInternalError, sendErr.Error(), false, false)
 		}
 	}()
 	return nil

--- a/client.go
+++ b/client.go
@@ -289,8 +289,7 @@ func (c *Client) sendCancel(
 }
 
 // sendAnonCancel sends an anonymous channel abort message to the client and
-// closes the anonymous channel, mirroring how sendCancel removes an outbound
-// request from requestResponseCh.
+// closes the anonymous channel.
 func (c *Client) sendAnonCancel(ctx context.Context, chanID int, reason error) error {
 	if reason == nil {
 		reason = context.Canceled
@@ -299,23 +298,22 @@ func (c *Client) sendAnonCancel(ctx context.Context, chanID int, reason error) e
 	ch := c.anonChans[chanID]
 	conn := c.conn
 	c.connReqMu.Unlock()
+	if ch != nil {
+		// Defer closing channel; otherwise `ctx` can be cancelled when writing
+		// cancellation message
+		defer ch.closeWithCause(reason)
+	}
 	if conn == nil {
-		if ch != nil {
-			ch.closeWithCause(reason)
-		}
 		return errClosed
 	}
-	err := conn.WriteMessage(ctx, &Message{
+	return conn.WriteMessage(ctx, &Message{
 		AnonymousChannel: chanID,
-		ResponseJSError:  true,
+		// Write as JS error
+		ResponseJSError: true,
 		CancelReason: map[string]any{
 			"message": reason.Error(),
 		},
 	})
-	if ch != nil {
-		ch.closeWithCause(reason)
-	}
-	return err
 }
 
 // sendResolve sends a resolve / data response to a request
@@ -346,7 +344,7 @@ func (c *Client) sendResolveAnon(ctx context.Context, requestID *int) error {
 	}
 	return conn.WriteMessage(ctx, &Message{
 		RequestID:        requestID,
-		AnonymousChannel: 1,
+		AnonymousChannel: 1, // send truthy value
 	})
 }
 

--- a/client.go
+++ b/client.go
@@ -14,6 +14,9 @@ import (
 // the context cancellation as a real connection error.
 var errRebound = errors.New("client bound to new connection")
 
+// errClosed is returned when an operation is attempted on a closed connection.
+var errClosed = errors.New("connection closed")
+
 // Client represents a WebSocket client
 type Client struct {
 	ClientChannel                     // the "main" client channel with no name
@@ -58,10 +61,10 @@ func NewClient(conn Conn) *Client {
 		// ClientChannel is set below
 		// ctx, ctxCancel, and conn are assigned in Bind method
 		requestResponseCh: make(map[int]chan messageResponse),
+		anonChans:         make(map[string]*AnonymousChannel),
 		inboundCancels:    make(map[int]func(error)),
 		handlers:          make(map[handlerName]any),
 		handlersOnce:      make(map[handlerName]any),
-		anonChans:         make(map[string]*AnonymousChannel),
 		data:              make(map[string]any),
 		// server is set only by Server.Accept
 	}
@@ -182,7 +185,7 @@ func (c *Client) close(
 	c.conn = nil
 	// Abort all pending outbound requests for this client.
 	for _, respCh := range c.requestResponseCh {
-		respCh <- messageResponse{nil, fmt.Errorf("connection closed")}
+		respCh <- messageResponse{nil, errClosed}
 		close(respCh)
 	}
 	clear(c.requestResponseCh)
@@ -192,7 +195,7 @@ func (c *Client) close(
 
 	// Close all anonymous channels (snapshot-clear-then-close to avoid deadlock).
 	for _, ch := range anonChans {
-		ch.closeWithCause(fmt.Errorf("connection closed"))
+		ch.closeWithCause(errClosed)
 	}
 
 	// Emit "close" events and close the connection
@@ -302,7 +305,7 @@ func (c *Client) sendEvent(ctx context.Context, channel string, anonymous bool, 
 	conn := c.conn
 	c.connReqMu.Unlock()
 	if conn == nil {
-		return fmt.Errorf("connection is closed")
+		return errClosed
 	}
 	// Encode arguments as JSON
 	jsonArgs := make([]json.RawMessage, len(arguments))
@@ -332,7 +335,7 @@ func (c *Client) sendRequest(
 	ctxClient := c.ctx
 	if conn == nil {
 		c.connReqMu.Unlock()
-		return nil, fmt.Errorf("connection is closed")
+		return nil, errClosed
 	}
 	// Create channel for message response
 	respCh := make(chan messageResponse, 1)
@@ -398,7 +401,7 @@ func (c *Client) sendAnonCancel(ctx context.Context, chanID string, reason error
 	conn := c.conn
 	c.connReqMu.Unlock()
 	if conn == nil {
-		return nil
+		return errClosed
 	}
 	return conn.WriteMessage(ctx, &Message{
 		AnonymousChannel: anonChannelH(chanID),

--- a/client.go
+++ b/client.go
@@ -705,6 +705,7 @@ func (c *Client) handleEvent(
 		if anonID != 0 {
 			err = fmt.Errorf("no event listener for '%s' on anonymous channel %d", eventName, anonID)
 		} else if chanID == "" {
+			// chanID is "" for the main (unnamed) channel
 			err = fmt.Errorf("no event listener for '%s'", eventName)
 		} else {
 			err = fmt.Errorf("no event listener for '%s' on channel '%s'", eventName, chanID)
@@ -762,6 +763,9 @@ func (c *Client) handleEvent(
 
 		// Handle request response: check the handler error first, then decide
 		// whether the handler returned the factory anonymous channel.
+		// Pointer identity is used intentionally: the handler must return the
+		// exact *AnonymousChannel obtained from Channel(ctx) — not a copy or a
+		// different channel with the same ID.
 		var sendErr error
 		if err != nil {
 			// Handler returned an error; clean up any factory channel created

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 )
 
@@ -585,9 +586,7 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// Get message event name if any
 	eventName := msg.EventName()
 	if eventName != "" {
-		return c.handleEvent(
-			ctx, msg, eventName, msg.Channel, msg.AnonymousChannel,
-		)
+		return c.handleEvent(ctx, msg, eventName)
 	}
 	// defer close(msg.processed) cannot go to the top of this function because
 	// handleEvent creates a goroutine that is responsible for closing
@@ -664,19 +663,13 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 }
 
 // handleEvent handles an inbound event or request on any channel.
-// chanID is the string channel name for named channels, or "" for anonymous
-// channels (anonID is used for map lookups and abort messages in that case).
 func (c *Client) handleEvent(
-	ctx context.Context,
-	msg Message,
-	eventName string,
-	chanID string,
-	anonID int,
+	ctx context.Context, msg Message, eventName string,
 ) error {
 	var cancel context.CancelCauseFunc
 
 	// For anonymous channels, verify the channel exists; send abort if not.
-	if anonID != 0 {
+	if anonID := msg.AnonymousChannel; anonID != 0 {
 		c.connReqMu.Lock()
 		_, ok := c.anonChans[anonID]
 		c.connReqMu.Unlock()
@@ -691,11 +684,13 @@ func (c *Client) handleEvent(
 		}
 	}
 
-	// Look up handler (client-specific first). For anonymous channels chanID
-	// is "" so the Channel field is empty and AnonymousChannel holds the
-	// numeric ID.
+	// Look up handler (client-specific first). For anonymous channels
+	// msg.AnonymousChannel is a positive numeric ID, and the Channel field is
+	// empty.
 	handlerID := handlerName{
-		Channel: chanID, AnonymousChannel: anonID, Event: eventName,
+		Channel:          msg.Channel,
+		AnonymousChannel: msg.AnonymousChannel,
+		Event:            eventName,
 	}
 	c.handlersMu.Lock()
 	handler, ok := c.handlersOnce[handlerID]
@@ -706,13 +701,12 @@ func (c *Client) handleEvent(
 	}
 	c.handlersMu.Unlock()
 
-	// For regular channels, get handlerCtxFunc and fall back to server
-	// handlers.
+	// Get handlerCtxFunc and try to use server handlers for regular channels.
 	var handlerCtxFunc HandlerContextFunc
 	if c.server != nil {
 		c.server.handlersMu.Lock()
 		handlerCtxFunc = c.server.handlerCtxFunc
-		if anonID == 0 && handler == nil {
+		if msg.AnonymousChannel == 0 && handler == nil {
 			handler, ok = c.server.handlersOnce[handlerID]
 			if ok {
 				delete(c.server.handlersOnce, handlerID)
@@ -727,17 +721,18 @@ func (c *Client) handleEvent(
 	if handler == nil {
 		defer close(msg.processed)
 		var err error
-		if anonID != 0 {
+		if msg.AnonymousChannel != 0 {
 			err = fmt.Errorf(
 				"no event listener for '%s' on anonymous channel %d",
-				eventName, anonID,
+				eventName, msg.AnonymousChannel,
 			)
-		} else if chanID == "" {
-			// chanID is "" for the main (unnamed) channel
+		} else if msg.Channel == "" {
+			// msg.Channel is "" for the main (unnamed) channel
 			err = fmt.Errorf("no event listener for '%s'", eventName)
 		} else {
 			err = fmt.Errorf(
-				"no event listener for '%s' on channel '%s'", eventName, chanID,
+				"no event listener for '%s' on channel '%s'",
+				eventName, msg.Channel,
 			)
 		}
 		if msg.RequestID != nil {
@@ -749,7 +744,11 @@ func (c *Client) handleEvent(
 	// Wrap context for handler execution
 	handlerCtx := ctx
 	if handlerCtxFunc != nil {
-		handlerCtx = handlerCtxFunc(ctx, chanID, eventName)
+		handlerCtxChanName := msg.Channel
+		if msg.AnonymousChannel != 0 {
+			handlerCtxChanName = strconv.Itoa(msg.AnonymousChannel)
+		}
+		handlerCtx = handlerCtxFunc(ctx, handlerCtxChanName, eventName)
 	}
 	// For inbound requests, create a cancellable context and inject the
 	// anonymous channel factory so handlers can call Channel(ctx).

--- a/client.go
+++ b/client.go
@@ -258,15 +258,13 @@ func (c *Client) sendReject(ctx context.Context, requestID *int, err error) erro
 	})
 }
 
-// sendCancel sends a cancellation signal for a request
+// sendCancel sends a cancellation signal for a request and removes it from
+// requestResponseCh.
 func (c *Client) sendCancel(
 	ctx context.Context,
 	requestID *int,
 	reason error,
 ) error {
-	if requestID == nil {
-		return fmt.Errorf("requestID is required")
-	}
 	if reason == nil {
 		reason = errors.New("Request aborted")
 	}
@@ -289,6 +287,26 @@ func (c *Client) sendCancel(
 	})
 }
 
+// sendAnonCancel sends an anonymous channel abort message to the client.
+func (c *Client) sendAnonCancel(ctx context.Context, chanID string, reason error) error {
+	if reason == nil {
+		reason = context.Canceled
+	}
+	c.connReqMu.Lock()
+	conn := c.conn
+	c.connReqMu.Unlock()
+	if conn == nil {
+		return errClosed
+	}
+	return conn.WriteMessage(ctx, &Message{
+		AnonymousChannel: anonChannelH(chanID),
+		ResponseJSError:  true,
+		CancelReason: map[string]any{
+			"message": reason.Error(),
+		},
+	})
+}
+
 // sendResolve sends a resolve / data response to a request
 func (c *Client) sendResolve(ctx context.Context, requestID *int, data any) error {
 	if requestID == nil {
@@ -303,6 +321,20 @@ func (c *Client) sendResolve(ctx context.Context, requestID *int, data any) erro
 	return conn.WriteMessage(ctx, &Message{
 		RequestID:    requestID,
 		ResponseData: data,
+	})
+}
+
+// sendResolveAnon sends an anonymous channel creation response to the client.
+func (c *Client) sendResolveAnon(ctx context.Context, requestID *int, chanID string) error {
+	c.connReqMu.Lock()
+	conn := c.conn
+	c.connReqMu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	return conn.WriteMessage(ctx, &Message{
+		RequestID:        requestID,
+		AnonymousChannel: anonChannelH(chanID),
 	})
 }
 
@@ -397,40 +429,6 @@ func (c *Client) sendRequest(
 		_ = c.sendCancel(ctxClient, &requestID, cancelCause)
 		return nil, fmt.Errorf("awaiting response: %w", cancelCause)
 	}
-}
-
-// sendAnonCancel sends an anonymous channel abort message to the client.
-func (c *Client) sendAnonCancel(ctx context.Context, chanID string, reason error) error {
-	if reason == nil {
-		reason = context.Canceled
-	}
-	c.connReqMu.Lock()
-	conn := c.conn
-	c.connReqMu.Unlock()
-	if conn == nil {
-		return errClosed
-	}
-	return conn.WriteMessage(ctx, &Message{
-		AnonymousChannel: anonChannelH(chanID),
-		ResponseJSError:  true,
-		CancelReason: map[string]any{
-			"message": reason.Error(),
-		},
-	})
-}
-
-// sendAnonCreation sends an anonymous channel creation response to the client.
-func (c *Client) sendAnonCreation(ctx context.Context, requestID *int, chanID string) error {
-	c.connReqMu.Lock()
-	conn := c.conn
-	c.connReqMu.Unlock()
-	if conn == nil {
-		return nil
-	}
-	return conn.WriteMessage(ctx, &Message{
-		RequestID:        requestID,
-		AnonymousChannel: anonChannelH(chanID),
-	})
 }
 
 // readMessages reads messages from the client connection and handles them.
@@ -562,10 +560,12 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	// Get message event name if any
 	eventName := msg.EventName()
 	if eventName != "" {
-		if msg.AnonymousChannel != "" {
-			return c.handleAnonChannelMessage(ctx, msg, eventName)
+		chanID := msg.Channel
+		anonymous := msg.AnonymousChannel != ""
+		if anonymous {
+			chanID = string(msg.AnonymousChannel)
 		}
-		return c.handleRegularMessage(ctx, msg, eventName)
+		return c.handleInboundMessage(ctx, msg, eventName, chanID, anonymous)
 	}
 	defer close(msg.processed)
 
@@ -638,16 +638,33 @@ func (c *Client) handleMessage(ctx context.Context, msg Message) error {
 	return nil
 }
 
-// handleRegularMessage handles an inbound event or request on a named or main
-// channel (msg.AnonymousChannel == "").
-func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventName string) error {
-	// We may create a request-specific cancellable context later
+// handleInboundMessage handles an inbound event or request on any channel.
+// chanID is the channel name (msg.Channel for regular, string(msg.AnonymousChannel)
+// for anonymous). anonymous mirrors the handlerName.Anonymous flag.
+func (c *Client) handleInboundMessage(
+	ctx context.Context, msg Message, eventName string,
+	chanID string, anonymous bool,
+) error {
 	var cancel context.CancelCauseFunc
 
-	// Process inbound event/request
-	handlerID := handlerName{Channel: msg.Channel, Anonymous: false, Event: eventName}
+	// For anonymous channels, verify the channel exists; send abort if not.
+	if anonymous {
+		c.connReqMu.Lock()
+		_, ok := c.anonChans[chanID]
+		c.connReqMu.Unlock()
+		if !ok {
+			defer close(msg.processed)
+			err := fmt.Errorf("anonymous channel '%s' not found", chanID)
+			_ = c.sendAnonCancel(ctx, chanID, err)
+			if msg.RequestID != nil {
+				return c.sendReject(ctx, msg.RequestID, err)
+			}
+			return nil
+		}
+	}
 
-	// Get client-specific handler
+	// Look up handler (client-specific first)
+	handlerID := handlerName{Channel: chanID, Anonymous: anonymous, Event: eventName}
 	c.handlersMu.Lock()
 	handler, ok := c.handlersOnce[handlerID]
 	if ok {
@@ -657,13 +674,12 @@ func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventNam
 	}
 	c.handlersMu.Unlock()
 
-	// Get server's handler context function
+	// For regular channels, get handlerCtxFunc and fall back to server handlers.
 	var handlerCtxFunc HandlerContextFunc
 	if c.server != nil {
 		c.server.handlersMu.Lock()
 		handlerCtxFunc = c.server.handlerCtxFunc
-		// Get server handler if no client handler exists
-		if handler == nil {
+		if !anonymous && handler == nil {
 			handler, ok = c.server.handlersOnce[handlerID]
 			if ok {
 				delete(c.server.handlersOnce, handlerID)
@@ -677,79 +693,65 @@ func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventNam
 	// Handle missing handler
 	if handler == nil {
 		defer close(msg.processed)
-		err := fmt.Errorf(
-			"no event listener for '%s' on channel '%s'",
-			eventName, msg.Channel,
-		)
-		if msg.Channel == "" {
+		err := fmt.Errorf("no event listener for '%s' on channel '%s'", eventName, chanID)
+		if chanID == "" {
 			err = fmt.Errorf("no event listener for '%s'", eventName)
 		}
-		// Send error response if it's a request
 		if msg.RequestID != nil {
 			return c.sendReject(ctx, msg.RequestID, err)
 		}
-		// Otherwise, ignore this message
 		return nil
 	}
 
 	// Wrap context for handler execution
 	handlerCtx := ctx
 	if handlerCtxFunc != nil {
-		handlerCtx = handlerCtxFunc(ctx, msg.Channel, eventName)
+		handlerCtx = handlerCtxFunc(ctx, chanID, eventName)
 	}
-	// For inbound requests, create a request-specific cancellable context and
-	// inject the anonymous channel factory.
+	// For inbound requests, create a cancellable context and inject the
+	// anonymous channel factory so handlers can call Channel(ctx).
 	var anonChan *AnonymousChannel
+	var newChanID string
 	if msg.RequestID != nil {
 		handlerCtx, cancel = context.WithCancelCause(handlerCtx)
-		// Save the CancelCauseFunc for the request
 		c.inboundCancelsMu.Lock()
 		c.inboundCancels[*msg.RequestID] = cancel
 		c.inboundCancelsMu.Unlock()
 
-		// Inject anonymous channel factory so the handler can call Channel(ctx)
-		chanID := strconv.Itoa(*msg.RequestID)
+		newChanID = strconv.Itoa(*msg.RequestID)
 		factory := func() *AnonymousChannel {
 			if anonChan == nil {
-				anonChan = newAnonymousChannel(ctx, chanID, c)
+				anonChan = newAnonymousChannel(ctx, newChanID, c)
 			}
 			return anonChan
 		}
 		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, factory)
 	}
 
-	// Call handler with arguments
 	go func() {
 		defer close(msg.processed)
-		result, err := callHandler(
-			handlerCtx, handler, msg.HandlerArguments(),
-		)
-		// We are done running the handler, so cancel the handler context
+		result, err := callHandler(handlerCtx, handler, msg.HandlerArguments())
 		if cancel != nil {
 			cancel(context.Canceled)
 		}
 
 		if msg.RequestID == nil {
-			// Silently ignore the response if it's not a request
 			if anonChan != nil {
 				anonChan.ctxCancel(context.Canceled) // cleanup unused factory
 			}
 			return
 		}
 
-		// Clean up inbound cancellation
 		c.inboundCancelsMu.Lock()
 		delete(c.inboundCancels, *msg.RequestID)
 		c.inboundCancelsMu.Unlock()
 
-		chanID := strconv.Itoa(*msg.RequestID)
-
 		// Check if handler returned the factory anonymous channel
 		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == anonChan {
 			c.connReqMu.Lock()
-			c.anonChans[chanID] = anon
+			c.anonChans[newChanID] = anon
 			c.connReqMu.Unlock()
-			sendErr := c.sendAnonCreation(ctx, msg.RequestID, chanID)
+			sendErr := c.sendResolveAnon(ctx, msg.RequestID, newChanID)
 			if sendErr != nil {
 				sendErr = fmt.Errorf("responding to request: %w", sendErr)
 				c.emitError(sendErr)
@@ -761,138 +763,6 @@ func (c *Client) handleRegularMessage(ctx context.Context, msg Message, eventNam
 			return
 		}
 		// Clean up unused factory channel if one was created
-		if anonChan != nil {
-			anonChan.ctxCancel(context.Canceled)
-		}
-
-		if err != nil {
-			// Send error response
-			err = c.sendReject(ctx, msg.RequestID, err)
-		} else {
-			// Send data response
-			err = c.sendResolve(ctx, msg.RequestID, result)
-		}
-		if err != nil {
-			// Emit error and close client
-			err = fmt.Errorf("responding to request: %w", err)
-			c.emitError(err)
-			if c.server != nil {
-				c.server.emitError(c, err)
-			}
-			c.close(StatusInternalError, err.Error(), false, false)
-		}
-	}()
-	return nil
-}
-
-// handleAnonChannelMessage handles an inbound event or request on an anonymous
-// channel (msg.AnonymousChannel != "").
-func (c *Client) handleAnonChannelMessage(ctx context.Context, msg Message, eventName string) error {
-	var anonCancel context.CancelCauseFunc
-	chanID := string(msg.AnonymousChannel)
-
-	// Lookup the anonymous channel
-	c.connReqMu.Lock()
-	_, ok := c.anonChans[chanID]
-	c.connReqMu.Unlock()
-	if !ok {
-		// Unknown anonymous channel: notify remote and reject any sub-request
-		defer close(msg.processed)
-		err := fmt.Errorf("anonymous channel '%s' not found", chanID)
-		_ = c.sendAnonCancel(ctx, chanID, err)
-		if msg.RequestID != nil {
-			return c.sendReject(ctx, msg.RequestID, err)
-		}
-		return nil
-	}
-
-	// Route to anonymous channel's handlers (client-side only; no server fallback)
-	handlerID := handlerName{Channel: chanID, Anonymous: true, Event: eventName}
-	c.handlersMu.Lock()
-	handler, ok := c.handlersOnce[handlerID]
-	if ok {
-		delete(c.handlersOnce, handlerID)
-	} else {
-		handler = c.handlers[handlerID]
-	}
-	c.handlersMu.Unlock()
-
-	// Handle missing handler for anonymous channel
-	if handler == nil {
-		defer close(msg.processed)
-		err := fmt.Errorf(
-			"no event listener for '%s' on anonymous channel '%s'",
-			eventName, chanID,
-		)
-		if msg.RequestID != nil {
-			return c.sendReject(ctx, msg.RequestID, err)
-		}
-		return nil
-	}
-
-	// Wrap context for handler execution
-	handlerCtx := ctx
-	if c.server != nil {
-		c.server.handlersMu.Lock()
-		handlerCtxFunc := c.server.handlerCtxFunc
-		c.server.handlersMu.Unlock()
-		if handlerCtxFunc != nil {
-			handlerCtx = handlerCtxFunc(ctx, chanID, eventName)
-		}
-	}
-	// For inbound sub-requests on anonymous channels, create a cancellable
-	// context and inject a nested anonymous channel factory.
-	var anonChan *AnonymousChannel
-	if msg.RequestID != nil {
-		handlerCtx, anonCancel = context.WithCancelCause(handlerCtx)
-		c.inboundCancelsMu.Lock()
-		c.inboundCancels[*msg.RequestID] = anonCancel
-		c.inboundCancelsMu.Unlock()
-
-		subChanID := strconv.Itoa(*msg.RequestID)
-		factory := func() *AnonymousChannel {
-			if anonChan == nil {
-				anonChan = newAnonymousChannel(ctx, subChanID, c)
-			}
-			return anonChan
-		}
-		handlerCtx = context.WithValue(handlerCtx, anonChannelKey{}, factory)
-	}
-
-	go func() {
-		defer close(msg.processed)
-		result, err := callHandler(handlerCtx, handler, msg.HandlerArguments())
-		if anonCancel != nil {
-			anonCancel(context.Canceled)
-		}
-		if msg.RequestID == nil {
-			if anonChan != nil {
-				anonChan.ctxCancel(context.Canceled)
-			}
-			return
-		}
-		c.inboundCancelsMu.Lock()
-		delete(c.inboundCancels, *msg.RequestID)
-		c.inboundCancelsMu.Unlock()
-
-		subChanID := strconv.Itoa(*msg.RequestID)
-
-		// Check if handler returned the factory anonymous channel
-		if anon, ok := result.(*AnonymousChannel); ok && anon != nil && anon == anonChan {
-			c.connReqMu.Lock()
-			c.anonChans[subChanID] = anon
-			c.connReqMu.Unlock()
-			sendErr := c.sendAnonCreation(ctx, msg.RequestID, subChanID)
-			if sendErr != nil {
-				sendErr = fmt.Errorf("responding to request: %w", sendErr)
-				c.emitError(sendErr)
-				if c.server != nil {
-					c.server.emitError(c, sendErr)
-				}
-				c.close(StatusInternalError, sendErr.Error(), false, false)
-			}
-			return
-		}
 		if anonChan != nil {
 			anonChan.ctxCancel(context.Canceled)
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -284,7 +284,10 @@ func TestSendCancel_DefaultReason(t *testing.T) {
 
 	reqID := 42
 	client.connReqMu.Lock()
-	client.requestResponseCh[reqID] = make(chan messageResponse, 1)
+	client.outboundRequests[reqID] = outboundRequest{
+		respCh: make(chan messageResponse, 1),
+		ctx:    context.Background(),
+	}
 	client.connReqMu.Unlock()
 	if err := client.sendCancel(context.Background(), &reqID, nil); err != nil {
 		t.Fatalf("sendCancel returned error: %v", err)

--- a/context.go
+++ b/context.go
@@ -2,18 +2,31 @@ package wrapper
 
 import "context"
 
-type contextKey string
-
-// ClientKey is the value to be passed to the context's Value method to return
-// the *wrapper.Client object that emitted the event.
-const ClientKey = contextKey("client")
+// clientKey is the context key to inject the *wrapper.Client object that
+// emitted the event into event handler contexts.
+type clientKey struct{}
 
 // ClientFromContext returns the WebSocket client from the given context.
 // Returns nil if not available.
 func ClientFromContext(ctx context.Context) *Client {
-	c, ok := ctx.Value(ClientKey).(*Client)
+	c, ok := ctx.Value(clientKey{}).(*Client)
 	if !ok {
 		return nil
 	}
 	return c
+}
+
+// anonChannelKey is the context key used to inject the anonymous channel
+// factory function into event handler contexts.
+type anonChannelKey struct{}
+
+// Channel returns the *AnonymousChannel for the current request handler
+// context, creating it lazily on the first call. It returns nil if called
+// outside of a request handler.
+func Channel(ctx context.Context) *AnonymousChannel {
+	factory, _ := ctx.Value(anonChannelKey{}).(func() *AnonymousChannel)
+	if factory == nil {
+		return nil
+	}
+	return factory()
 }

--- a/example_anon_channel_test.go
+++ b/example_anon_channel_test.go
@@ -1,0 +1,52 @@
+package wrapper_test
+
+import (
+	"context"
+	"fmt"
+
+	wrapper "github.com/bminer/ws-server-wrapper-go"
+)
+
+// ExampleChannel shows how to stream events from a server handler back to the
+// requesting client using an anonymous channel.
+//
+// The handler calls [Channel] to obtain an *[AnonymousChannel] tied to the
+// current request, launches a goroutine that emits a series of "data" events
+// followed by an "end" event, and returns the channel so the library can send
+// the creation response to the client.
+//
+// On the client side the [Client.Request] return value is a *[AnonymousChannel]
+// when the server responds with a channel. Register handlers on it before any
+// events can arrive:
+//
+//	resp, err := client.Request(ctx, "subscribe", "news")
+//	if err == nil {
+//	    if ch, ok := resp.(*wrapper.AnonymousChannel); ok {
+//	        ch.On("data", func(update string) error {
+//	            fmt.Println("update:", update)
+//	            return nil
+//	        })
+//	    }
+//	}
+func ExampleChannel() {
+	wsServer := wrapper.NewServer()
+
+	updates := []string{"first", "second", "third"}
+
+	wsServer.On("subscribe", func(ctx context.Context, topic string) (*wrapper.AnonymousChannel, error) {
+		ch := wrapper.Channel(ctx) // obtain the anonymous channel for this request
+		go func() {
+			defer ch.Close()
+			for _, u := range updates {
+				msg := fmt.Sprintf("[%s] %s", topic, u)
+				if err := ch.Emit(ch.Context(), "data", msg); err != nil {
+					return // client disconnected or aborted
+				}
+			}
+			ch.Emit(ch.Context(), "end") //nolint:errcheck
+		}()
+		return ch, nil
+	})
+
+	_ = wsServer
+}

--- a/handlers.go
+++ b/handlers.go
@@ -213,9 +213,6 @@ func registerClientHandler(
 			delete(c.handlers, key)
 		}
 	} else {
-		// For anonymous channels, pass a non-empty channel name so that
-		// checkHandler validates the function signature without enforcing the
-		// reserved-event signatures (open, close, etc.).
 		chanName := key.Channel
 		if key.AnonymousChannel != 0 {
 			chanName = strconv.Itoa(key.AnonymousChannel)

--- a/handlers.go
+++ b/handlers.go
@@ -43,8 +43,9 @@ func IsReservedEvent(eventName string) bool {
 // handlerName is a unique name for a handler function having the specified
 // channel and event name.
 type handlerName struct {
-	Channel string
-	Event   string
+	Channel   string
+	Anonymous bool   // true for anonymous (request-scoped) channel handlers
+	Event     string
 }
 
 var errorType = reflect.TypeFor[error]()
@@ -177,18 +178,35 @@ func emitReserved(
 // channel from both persistent and one-time handler maps.
 func closeHandlersForChannel(
 	channel string,
+	anonymous bool,
 	handlers map[handlerName]any,
 	handlersOnce map[handlerName]any,
 ) {
 	for key := range handlers {
-		if key.Channel == channel {
+		if key.Channel == channel && key.Anonymous == anonymous {
 			delete(handlers, key)
 		}
 	}
 	for key := range handlersOnce {
-		if key.Channel == channel {
+		if key.Channel == channel && key.Anonymous == anonymous {
 			delete(handlersOnce, key)
 		}
+	}
+}
+
+// registerHandler adds a handler for the given channel, event, and anonymous
+// flag to the appropriate handler map. It acquires the client's handlersMu.
+func registerHandler(cl *Client, channel, event string, anonymous bool, handler any, once bool) {
+	cl.handlersMu.Lock()
+	defer cl.handlersMu.Unlock()
+	name := handlerName{Channel: channel, Anonymous: anonymous, Event: event}
+	if handler == nil {
+		delete(cl.handlers, name)
+		delete(cl.handlersOnce, name)
+	} else if once {
+		cl.handlersOnce[name] = handler
+	} else {
+		cl.handlers[name] = handler
 	}
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -44,7 +44,7 @@ func IsReservedEvent(eventName string) bool {
 // channel and event name.
 type handlerName struct {
 	Channel   string
-	Anonymous bool   // true for anonymous (request-scoped) channel handlers
+	Anonymous bool // true for anonymous (request-scoped) channel handlers
 	Event     string
 }
 
@@ -194,19 +194,33 @@ func closeHandlersForChannel(
 	}
 }
 
-// registerHandler adds a handler for the given channel, event, and anonymous
-// flag to the appropriate handler map. It acquires the client's handlersMu.
-func registerHandler(cl *Client, channel, event string, anonymous bool, handler any, once bool) {
-	cl.handlersMu.Lock()
-	defer cl.handlersMu.Unlock()
-	name := handlerName{Channel: channel, Anonymous: anonymous, Event: event}
+// registerClientHandler adds a handler for the given channel and event to the
+// appropriate handler map. It acquires the client's handlersMu.
+func registerClientHandler(
+	c *Client,
+	key handlerName,
+	handler any,
+	once bool,
+) {
 	if handler == nil {
-		delete(cl.handlers, name)
-		delete(cl.handlersOnce, name)
-	} else if once {
-		cl.handlersOnce[name] = handler
+		c.handlersMu.Lock()
+		defer c.handlersMu.Unlock()
+		if once {
+			delete(c.handlersOnce, key)
+		} else {
+			delete(c.handlers, key)
+		}
 	} else {
-		cl.handlers[name] = handler
+		if err := checkHandler(key.Channel, key.Event, handler); err != nil {
+			panic(err)
+		}
+		c.handlersMu.Lock()
+		defer c.handlersMu.Unlock()
+		if once {
+			c.handlersOnce[key] = handler
+		} else {
+			c.handlers[key] = handler
+		}
 	}
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -40,12 +40,13 @@ func IsReservedEvent(eventName string) bool {
 	}
 }
 
-// handlerName is a unique name for a handler function having the specified
-// channel and event name.
+// handlerName is a unique key for a handler function. For named and main
+// channels AnonymousChannel is zero; for anonymous (request-scoped) channels
+// Channel is empty and AnonymousChannel holds the numeric channel ID.
 type handlerName struct {
-	Channel   string
-	Anonymous bool // true for anonymous (request-scoped) channel handlers
-	Event     string
+	Channel          string
+	AnonymousChannel int
+	Event            string
 }
 
 var errorType = reflect.TypeFor[error]()
@@ -178,17 +179,17 @@ func emitReserved(
 // channel from both persistent and one-time handler maps.
 func closeHandlersForChannel(
 	channel string,
-	anonymous bool,
+	anonID int,
 	handlers map[handlerName]any,
 	handlersOnce map[handlerName]any,
 ) {
 	for key := range handlers {
-		if key.Channel == channel && key.Anonymous == anonymous {
+		if key.Channel == channel && key.AnonymousChannel == anonID {
 			delete(handlers, key)
 		}
 	}
 	for key := range handlersOnce {
-		if key.Channel == channel && key.Anonymous == anonymous {
+		if key.Channel == channel && key.AnonymousChannel == anonID {
 			delete(handlersOnce, key)
 		}
 	}
@@ -211,8 +212,10 @@ func registerClientHandler(
 			delete(c.handlers, key)
 		}
 	} else {
-		if err := checkHandler(key.Channel, key.Event, handler); err != nil {
-			panic(err)
+		if key.AnonymousChannel == 0 {
+			if err := checkHandler(key.Channel, key.Event, handler); err != nil {
+				panic(err)
+			}
 		}
 		c.handlersMu.Lock()
 		defer c.handlersMu.Unlock()

--- a/handlers.go
+++ b/handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"sync"
 )
 
@@ -212,10 +213,15 @@ func registerClientHandler(
 			delete(c.handlers, key)
 		}
 	} else {
-		if key.AnonymousChannel == 0 {
-			if err := checkHandler(key.Channel, key.Event, handler); err != nil {
-				panic(err)
-			}
+		// For anonymous channels, pass a non-empty channel name so that
+		// checkHandler validates the function signature without enforcing the
+		// reserved-event signatures (open, close, etc.).
+		chanName := key.Channel
+		if key.AnonymousChannel != 0 {
+			chanName = strconv.Itoa(key.AnonymousChannel)
+		}
+		if err := checkHandler(chanName, key.Event, handler); err != nil {
+			panic(err)
 		}
 		c.handlersMu.Lock()
 		defer c.handlersMu.Unlock()

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -260,13 +260,13 @@ func TestClientChannelCloseRemovesChannelHandlers(t *testing.T) {
 		t.Fatalf("unexpected close error: %v", err)
 	}
 
-	if _, ok := client.handlers[handlerName{Channel: "room", Anonymous: false, Event: "a"}]; ok {
+	if _, ok := client.handlers[handlerName{Channel: "room", Event: "a"}]; ok {
 		t.Fatal("expected persistent room handler to be removed")
 	}
-	if _, ok := client.handlersOnce[handlerName{Channel: "room", Anonymous: false, Event: "b"}]; ok {
+	if _, ok := client.handlersOnce[handlerName{Channel: "room", Event: "b"}]; ok {
 		t.Fatal("expected once room handler to be removed")
 	}
-	if _, ok := client.handlers[handlerName{Channel: "other", Anonymous: false, Event: "a"}]; !ok {
+	if _, ok := client.handlers[handlerName{Channel: "other", Event: "a"}]; !ok {
 		t.Fatal("expected handlers for other channels to be preserved")
 	}
 }
@@ -283,13 +283,13 @@ func TestServerChannelCloseRemovesChannelHandlers(t *testing.T) {
 		t.Fatalf("unexpected close error: %v", err)
 	}
 
-	if _, ok := server.handlers[handlerName{Channel: "room", Anonymous: false, Event: "a"}]; ok {
+	if _, ok := server.handlers[handlerName{Channel: "room", Event: "a"}]; ok {
 		t.Fatal("expected persistent room handler to be removed")
 	}
-	if _, ok := server.handlersOnce[handlerName{Channel: "room", Anonymous: false, Event: "b"}]; ok {
+	if _, ok := server.handlersOnce[handlerName{Channel: "room", Event: "b"}]; ok {
 		t.Fatal("expected once room handler to be removed")
 	}
-	if _, ok := server.handlers[handlerName{Channel: "other", Anonymous: false, Event: "a"}]; !ok {
+	if _, ok := server.handlers[handlerName{Channel: "other", Event: "a"}]; !ok {
 		t.Fatal("expected handlers for other channels to be preserved")
 	}
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -260,13 +260,13 @@ func TestClientChannelCloseRemovesChannelHandlers(t *testing.T) {
 		t.Fatalf("unexpected close error: %v", err)
 	}
 
-	if _, ok := client.handlers[handlerName{Channel: "room", Event: "a"}]; ok {
+	if _, ok := client.handlers[handlerName{Channel: "room", Anonymous: false, Event: "a"}]; ok {
 		t.Fatal("expected persistent room handler to be removed")
 	}
-	if _, ok := client.handlersOnce[handlerName{Channel: "room", Event: "b"}]; ok {
+	if _, ok := client.handlersOnce[handlerName{Channel: "room", Anonymous: false, Event: "b"}]; ok {
 		t.Fatal("expected once room handler to be removed")
 	}
-	if _, ok := client.handlers[handlerName{Channel: "other", Event: "a"}]; !ok {
+	if _, ok := client.handlers[handlerName{Channel: "other", Anonymous: false, Event: "a"}]; !ok {
 		t.Fatal("expected handlers for other channels to be preserved")
 	}
 }
@@ -283,13 +283,13 @@ func TestServerChannelCloseRemovesChannelHandlers(t *testing.T) {
 		t.Fatalf("unexpected close error: %v", err)
 	}
 
-	if _, ok := server.handlers[handlerName{Channel: "room", Event: "a"}]; ok {
+	if _, ok := server.handlers[handlerName{Channel: "room", Anonymous: false, Event: "a"}]; ok {
 		t.Fatal("expected persistent room handler to be removed")
 	}
-	if _, ok := server.handlersOnce[handlerName{Channel: "room", Event: "b"}]; ok {
+	if _, ok := server.handlersOnce[handlerName{Channel: "room", Anonymous: false, Event: "b"}]; ok {
 		t.Fatal("expected once room handler to be removed")
 	}
-	if _, ok := server.handlers[handlerName{Channel: "other", Event: "a"}]; !ok {
+	if _, ok := server.handlers[handlerName{Channel: "other", Anonymous: false, Event: "a"}]; !ok {
 		t.Fatal("expected handlers for other channels to be preserved")
 	}
 }

--- a/message.go
+++ b/message.go
@@ -97,11 +97,13 @@ func (m Message) Response() (any, error) {
 	return nil, errors.New(errMsg)
 }
 
-// parseCancelReason extracts a cancel/abort reason from the message's
-// CancelReason and ResponseJSError fields.
-func (m Message) parseCancelReason() error {
+// CancelCause returns the cancel/abort reason from this message as an error.
+// Works for both inbound request cancellations ({i, x}) and anonymous channel
+// aborts ({h, x}). Returns "message is not a cancellation" if CancelReason is
+// nil; returns context.Canceled if the reason cannot be parsed.
+func (m Message) CancelCause() error {
 	if m.CancelReason == nil {
-		return context.Canceled
+		return errors.New("message is not a cancellation")
 	}
 	// Handle JavaScript error
 	if m.ResponseJSError {
@@ -126,15 +128,6 @@ func (m Message) parseCancelReason() error {
 		return context.Canceled
 	}
 	return errors.New(errMsg)
-}
-
-// CancelCause returns the reason for this cancellation message as an error.
-// Returns context.Canceled if no reason is provided.
-func (m Message) CancelCause() error {
-	if m.RequestID == nil || m.CancelReason == nil {
-		return errors.New("message is not a cancellation")
-	}
-	return m.parseCancelReason()
 }
 
 func (m Message) LogValue() slog.Value {

--- a/message.go
+++ b/message.go
@@ -25,18 +25,43 @@ func (bit *weakBool) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// anonChannelH represents the "h" field in an anonymous channel message.
+// The JS library sends a bare number (e.g. 1) as the creation sentinel; Go
+// sends a string channel ID. Custom unmarshalling maps any truthy number to
+// the string "1" so that downstream code only needs to check for "".
+type anonChannelH string
+
+func (h *anonChannelH) UnmarshalJSON(data []byte) error {
+	// Try string first (Go → JS messages use a string channel ID)
+	var s string
+	if json.Unmarshal(data, &s) == nil {
+		*h = anonChannelH(s)
+		return nil
+	}
+	// Fall back to number (JS sends h:1 as creation sentinel)
+	var n float64
+	if json.Unmarshal(data, &n) == nil {
+		if n != 0 {
+			*h = "1"
+		}
+		return nil
+	}
+	return nil
+}
+
 // Message is a ws-wrapper JSON-encoded message.
 // See https://github.com/bminer/ws-wrapper/blob/master/README.md#protocol
 type Message struct {
-	Channel         string            `json:"c,omitempty"`
-	Arguments       []json.RawMessage `json:"a,omitempty"` // Arguments[0] is the event name
-	RequestID       *int              `json:"i,omitempty"`
-	ResponseData    any               `json:"d,omitempty"`
-	ResponseError   any               `json:"e,omitempty"`
-	ResponseJSError weakBool          `json:"_,omitempty"`
-	CancelReason    any               `json:"x,omitempty"` // Request cancellation signal
-	IgnoreIfFalse   *weakBool         `json:"ws-wrapper,omitempty"`
-	processed       chan struct{}
+	Channel          string            `json:"c,omitempty"`
+	AnonymousChannel anonChannelH      `json:"h,omitempty"`
+	Arguments        []json.RawMessage `json:"a,omitempty"` // Arguments[0] is the event name
+	RequestID        *int              `json:"i,omitempty"`
+	ResponseData     any               `json:"d,omitempty"`
+	ResponseError    any               `json:"e,omitempty"`
+	ResponseJSError  weakBool          `json:"_,omitempty"`
+	CancelReason     any               `json:"x,omitempty"` // Request cancellation signal
+	IgnoreIfFalse    *weakBool         `json:"ws-wrapper,omitempty"`
+	processed        chan struct{}
 }
 
 // EventName returns the name of the event or empty string if the message is
@@ -96,11 +121,11 @@ func (m Message) Response() (any, error) {
 	return nil, errors.New(errMsg)
 }
 
-// CancelCause returns the reason for this cancellation message as an error.
-// Returns context.Canceled if no reason is provided.
-func (m Message) CancelCause() error {
-	if m.RequestID == nil || m.CancelReason == nil {
-		return errors.New("message is not a cancellation")
+// parseCancelReason extracts a cancel/abort reason from the message's
+// CancelReason and ResponseJSError fields.
+func (m Message) parseCancelReason() error {
+	if m.CancelReason == nil {
+		return context.Canceled
 	}
 	// Handle JavaScript error
 	if m.ResponseJSError {
@@ -127,6 +152,15 @@ func (m Message) CancelCause() error {
 	return errors.New(errMsg)
 }
 
+// CancelCause returns the reason for this cancellation message as an error.
+// Returns context.Canceled if no reason is provided.
+func (m Message) CancelCause() error {
+	if m.RequestID == nil || m.CancelReason == nil {
+		return errors.New("message is not a cancellation")
+	}
+	return m.parseCancelReason()
+}
+
 func (m Message) LogValue() slog.Value {
 	if m.IgnoreIfFalse != nil && !*m.IgnoreIfFalse {
 		return slog.GroupValue(slog.Bool("ignored", true))
@@ -136,8 +170,12 @@ func (m Message) LogValue() slog.Value {
 	eventName := m.EventName()
 	const MaxArgLength = 1024
 	if eventName != "" {
+		ch := m.Channel
+		if m.AnonymousChannel != "" {
+			ch = "~" + string(m.AnonymousChannel) // prefix to distinguish anon channels
+		}
 		attrs = []slog.Attr{
-			slog.String("ch", m.Channel),
+			slog.String("ch", ch),
 			slog.String("event", eventName),
 		}
 		for i, arg := range m.HandlerArguments() {

--- a/message.go
+++ b/message.go
@@ -25,35 +25,11 @@ func (bit *weakBool) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// anonChannelH represents the "h" field in an anonymous channel message.
-// The JS library sends a bare number (e.g. 1) as the creation sentinel; Go
-// sends a string channel ID. Custom unmarshalling maps any truthy number to
-// the string "1" so that downstream code only needs to check for "".
-type anonChannelH string
-
-func (h *anonChannelH) UnmarshalJSON(data []byte) error {
-	// Try string first (Go → JS messages use a string channel ID)
-	var s string
-	if json.Unmarshal(data, &s) == nil {
-		*h = anonChannelH(s)
-		return nil
-	}
-	// Fall back to number (JS sends h:1 as creation sentinel)
-	var n float64
-	if json.Unmarshal(data, &n) == nil {
-		if n != 0 {
-			*h = "1"
-		}
-		return nil
-	}
-	return nil
-}
-
 // Message is a ws-wrapper JSON-encoded message.
 // See https://github.com/bminer/ws-wrapper/blob/master/README.md#protocol
 type Message struct {
 	Channel          string            `json:"c,omitempty"`
-	AnonymousChannel anonChannelH      `json:"h,omitempty"`
+	AnonymousChannel int               `json:"h,omitempty"`
 	Arguments        []json.RawMessage `json:"a,omitempty"` // Arguments[0] is the event name
 	RequestID        *int              `json:"i,omitempty"`
 	ResponseData     any               `json:"d,omitempty"`
@@ -171,8 +147,8 @@ func (m Message) LogValue() slog.Value {
 	const MaxArgLength = 1024
 	if eventName != "" {
 		ch := m.Channel
-		if m.AnonymousChannel != "" {
-			ch = "~" + string(m.AnonymousChannel) // prefix to distinguish anon channels
+		if m.AnonymousChannel != 0 {
+			ch = "~" + strconv.Itoa(m.AnonymousChannel) // prefix to distinguish anon channels
 		}
 		attrs = []slog.Attr{
 			slog.String("ch", ch),

--- a/message.go
+++ b/message.go
@@ -146,13 +146,16 @@ func (m Message) LogValue() slog.Value {
 	eventName := m.EventName()
 	const MaxArgLength = 1024
 	if eventName != "" {
-		ch := m.Channel
 		if m.AnonymousChannel != 0 {
-			ch = "~" + strconv.Itoa(m.AnonymousChannel) // prefix to distinguish anon channels
-		}
-		attrs = []slog.Attr{
-			slog.String("ch", ch),
-			slog.String("event", eventName),
+			attrs = []slog.Attr{
+				slog.Int("anonCh", m.AnonymousChannel),
+				slog.String("event", eventName),
+			}
+		} else {
+			attrs = []slog.Attr{
+				slog.String("ch", m.Channel),
+				slog.String("event", eventName),
+			}
 		}
 		for i, arg := range m.HandlerArguments() {
 			if len(arg) > MaxArgLength {

--- a/message.go
+++ b/message.go
@@ -167,20 +167,36 @@ func (m Message) LogValue() slog.Value {
 		if m.RequestID != nil {
 			attrs = append(attrs, slog.Int("reqID", *m.RequestID))
 		}
+	} else if m.AnonymousChannel != 0 && m.CancelReason != nil {
+		// Anonymous channel abort: {h, x}
+		attrs = []slog.Attr{
+			slog.Int("anonCh", m.AnonymousChannel),
+			slog.Any("cancelReason", m.CancelReason),
+			slog.Bool("jsError", bool(m.ResponseJSError)),
+		}
 	} else if m.RequestID != nil {
-		if m.CancelReason != nil {
+		if m.AnonymousChannel != 0 {
+			// Anonymous channel creation: {i, h} (channel ID == request ID)
+			attrs = []slog.Attr{
+				slog.Int("reqID", *m.RequestID),
+				slog.Bool("anonChCreated", true),
+			}
+		} else if m.CancelReason != nil {
+			// Request cancellation: {i, x}
 			attrs = []slog.Attr{
 				slog.Int("reqID", *m.RequestID),
 				slog.Any("cancelReason", m.CancelReason),
 				slog.Bool("jsError", bool(m.ResponseJSError)),
 			}
 		} else if m.ResponseError != nil {
+			// Response rejection: {i, e}
 			attrs = []slog.Attr{
 				slog.Int("reqID", *m.RequestID),
 				slog.Any("error", m.ResponseError),
 				slog.Bool("jsError", bool(m.ResponseJSError)),
 			}
 		} else {
+			// Response resolution: {i, d}
 			attrs = []slog.Attr{
 				slog.Int("reqID", *m.RequestID),
 				slog.Any("data", m.ResponseData),

--- a/message_test.go
+++ b/message_test.go
@@ -167,10 +167,11 @@ func TestMessageCancelCause(t *testing.T) {
 	reqID := 1
 
 	t.Run("missing request ID", func(t *testing.T) {
+		// CancelCause works for anonymous-channel aborts too (no RequestID).
 		msg := Message{CancelReason: "user cancelled"}
 		err := msg.CancelCause()
-		if err == nil || err.Error() != "message is not a cancellation" {
-			t.Errorf("expected 'message is not a cancellation', got %v", err)
+		if err == nil || err.Error() != "user cancelled" {
+			t.Errorf("expected 'user cancelled', got %v", err)
 		}
 	})
 


### PR DESCRIPTION
Add AnonymousChannel for bidirectional request-scoped sub-channels

A request handler can now return an `*AnonymousChannel` to open a bidirectional, request-scoped sub-channel over the same WebSocket connection. This allows handlers to stream events or exchange multiple messages with the client asynchronously after the initial request.